### PR TITLE
Update docs and compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ output.c
 
 # Zig
 .zig-cache
-zig-out
+zig-out/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following guides explain how to set up and use Dream on Linux and Windows. T
 
    ```bash
    sudo apt update
-   sudo apt install -y build-essential cmake nasm gcc
+   sudo apt install -y build-essential zig gcc
    ```
 
 2. **Clone the repository**
@@ -35,27 +35,24 @@ The following guides explain how to set up and use Dream on Linux and Windows. T
 3. **Build the compiler**
 
    ```bash
-   mkdir build && cd build
-   cmake ..
-   cmake --build .
+   zig build
    ```
 
 4. **Compile and run the example**
 
    ```bash
-   ./DreamCompiler ../example.dr
-   ./dream
+   zig build run -- example.dr
    ```
 
 5. **Run the tests (optional)**
 
    ```bash
-   for f in ../tests/*.dr; do ./DreamCompiler $f; ./dream; done
+   for f in tests/*.dr; do zig build run -- $f; done
    ```
 
 ### Windows
 
-1. **Install tools**: [Git for Windows](https://git-scm.com/), [CMake](https://cmake.org/download/), [MinGW‑w64](http://mingw-w64.org/doku.php) and [NASM](https://www.nasm.us/). Make sure `gcc`, `cmake` and `nasm` are in your `PATH`.
+1. **Install tools**: [Git for Windows](https://git-scm.com/) and [Zig](https://ziglang.org/download/). Ensure `zig` is available from the command prompt.
 
 2. **Clone the repository** using *Git Bash* or *Command Prompt*:
 
@@ -67,38 +64,33 @@ The following guides explain how to set up and use Dream on Linux and Windows. T
 3. **Build the compiler**
 
    ```cmd
-   mkdir build && cd build
-   cmake ..
-   cmake --build .
+   zig build
    ```
 
 4. **Compile and run the example**
 
    ```cmd
-   DreamCompiler ..\example.dr
-   dream.exe
+   zig build run -- example.dr
    ```
 
-5. **Run the tests (optional)** following a similar loop in `cmd` or PowerShell.
+5. **Run the tests (optional)** using a simple loop in `cmd` or PowerShell.
 
 ## Building
 
-Dream uses CMake. The quickest way to build on a Unix‑like system is:
+Dream is built with Zig. The simplest approach is:
 
 ```bash
-mkdir build && cd build
-cmake ..
-cmake --build .
+zig build
 ```
 
-This produces the `DreamCompiler` executable inside the `build` directory.
+This places the `DreamCompiler` executable under `zig-out/bin`.
 
 ## Using the Compiler
 
 Invoke the compiler with a `.dr` source file:
 
 ```bash
-./DreamCompiler path/to/file.dr
+./zig-out/bin/DreamCompiler path/to/file.dr
 ```
 
 The compiler writes `output.c` and compiles it into a runnable executable called `dream` in the current directory. Run the resulting program with:
@@ -111,7 +103,7 @@ An example program is provided in [example.dr](example.dr).
 
 ## Tests
 
-Simple language features are covered by tests in the [`tests`](tests) directory. After building the compiler, run each test file through `DreamCompiler` and then execute the generated `dream` binary.
+Simple language features are covered by tests in the [`tests`](tests) directory. After building the compiler, run each test file using `zig build run -- <file>` which will compile the test and execute the resulting program.
 
 ## Documentation
 

--- a/docs/arithmetic.md
+++ b/docs/arithmetic.md
@@ -1,4 +1,4 @@
-﻿Arithmetic in Dream
+Arithmetic in Dream
 Overview
 Dream supports basic arithmetic operations, currently limited to addition (+).
 Syntax

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,4 @@
-﻿Dream Compiler Changelog
+Dream Compiler Changelog
 Version 0.1 (2025-07-14)
 
 Initial compiler implementation in dream.c.

--- a/docs/console.md
+++ b/docs/console.md
@@ -1,4 +1,4 @@
-﻿Console Output in Dream
+Console Output in Dream
 Overview
 Dream provides Console.WriteLine for outputting values to the console, similar to C#.
 Syntax

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-﻿Dream Language Usage Guide
+Dream Language Usage Guide
 Overview
 Dream is a programming language with C#-like, semicolon-based syntax, compiled to C code. This guide covers the current syntax and usage.
 Syntax
@@ -16,10 +16,12 @@ Console.WriteLine(x); // Outputs 15
 
 Compilation
 
-Write a .dr file (e.g., example.dr).
-Compile: dream.exe example.dr (generates output.c).
-Compile C: gcc output.c -o dream_exec.exe.
-Run: dream_exec.exe.
+Write a `.dr` file (e.g., `example.dr`).
+Compile and run:
+```
+zig build run -- example.dr
+```
+The compiler uses the `CC` environment variable for the back-end C compilation step. If `CC` is not set, `gcc` is used by default.
 
 Notes
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,4 +1,4 @@
-﻿Variables in Dream
+Variables in Dream
 Overview
 The Dream language supports variable declarations and assignments with a C#-like syntax, using the int type for integers.
 Syntax

--- a/example.dr
+++ b/example.dr
@@ -1,0 +1,5 @@
+int a = 1;
+int b = 2;
+int c;
+c = a + b;
+Console.WriteLine(c);

--- a/tests/test_arithmetic.dr
+++ b/tests/test_arithmetic.dr
@@ -1,4 +1,4 @@
-﻿int x = 5;
+int x = 5;
 int y = 10;
 x = y + 5;
 Console.WriteLine(x); // Expected: 15

--- a/tests/test_console.dr
+++ b/tests/test_console.dr
@@ -1,2 +1,2 @@
-﻿int x = 25;
+int x = 25;
 Console.WriteLine(x); // Expected: 25


### PR DESCRIPTION
## Summary
- switch build instructions to use zig instead of cmake
- add example.dr program
- use $CC during compilation in `dream.c`
- add recursive AST cleanup
- introduce NODE_IDENTIFIER for variable references
- clean BOM characters from docs and tests

## Testing
- `gcc -std=c11 -Wall -Wextra -D_GNU_SOURCE src/dream.c -o DreamCompiler`
- `for f in tests/*.dr example.dr; do ./DreamCompiler $f && ./dream; done`

------
https://chatgpt.com/codex/tasks/task_e_68757e14a9e8832bacb7a041dd918717