### PR TITLE
Fix build.zig for Zig 0.15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,20 +14,25 @@ pub fn build(b: *std.Build) void {
 
     // -------- Executable --------------------------------------------------
     const exe = b.addExecutable(.{
-        .name     = "DreamCompiler",
-        .target   = target,
-        .optimize = optimize,
+        .name = "DreamCompiler",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
-    exe.addCSourceFiles(&.{
-        "src/main.c",
-        "src/lexer.c",
-        "src/parser.c",
-        "src/codegen.c",
-    }, &.{
-        "-std=c11",
-        "-Wall",
-        "-Wextra",
+    exe.addCSourceFiles(.{
+        .files = &.{
+            "src/main.c",
+            "src/lexer.c",
+            "src/parser.c",
+            "src/codegen.c",
+        },
+        .flags = &.{
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+        },
     });
 
     exe.linkLibC();


### PR DESCRIPTION
## Summary
- update build script to the latest Zig build API

## Testing
- `zig build --summary all`
- `for f in tests/*.dr; do zig build run -- $f && ./build/bin/dream.exe; done`

------
https://chatgpt.com/codex/tasks/task_e_687590fe2300832bbbfe64e7e5de042d