### PR TITLE
Improve README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,56 @@
 # Dream Compiler
 
-Dream is a minimal compiler that transforms a C#-like language into C code. The project is experimental but aims to grow into a fully featured compiler. This repository contains the source for the compiler, example code, tests and documentation.
+Dream is a minimal compiler that transforms a C#-like language into C code. The project is experimental but aims to grow into a fully featured compiler. This repository contains the source, example code, tests and documentation.
 
 ## Features
 
 The compiler currently supports:
 
-- Integer variable declarations and assignments
-- Basic arithmetic using `+` and `-`
+- Integer variables and assignments
+- Basic arithmetic with `+` and `-`
 - Console output via `Console.WriteLine`
 - Simple `if` statements
 - `while` loops
 
-More features such as functions and string output are planned for future versions. See the [changelog](docs/changelog.md) for the current status.
+More features such as functions and string output are planned for future versions. See the [changelog](docs/changelog.md) for details.
 
 ## Getting Started
 
-The following guides explain how to set up and use Dream on Linux and Windows. They assume no prior software experience.
+The steps below show how to build and use Dream on both Linux and Windows.
 
-### Linux
-
-1. **Install dependencies**
-
-   ```bash
-   sudo apt update
-   sudo apt install -y build-essential zig gcc
-   ```
-
+1. **Install prerequisites**
+   - Linux: `sudo apt update && sudo apt install -y build-essential gcc`
+   - Download Zig 0.15.0: [Linux x86_64 build](https://ziglang.org/builds/zig-x86_64-linux-0.15.0-dev.936+fc2c1883b.tar.xz) or [Windows aarch64 build](https://ziglang.org/builds/zig-aarch64-windows-0.15.0-dev.936+fc2c1883b.zip). Extract the archive and add the `zig` binary to your `PATH`.
+   - Windows also requires [Git for Windows](https://git-scm.com/).
 2. **Clone the repository**
-
    ```bash
    git clone https://github.com/Ddemon26/DreamCompiler.git
    cd DreamCompiler
    ```
-
 3. **Build the compiler**
-
    ```bash
    zig build
    ```
-
-4. **Compile and run the example**
-
+4. **Run the example**
    ```bash
    zig build run -- example.dr
    ```
-
 5. **Run the tests (optional)**
-
    ```bash
-   for f in tests/*.dr; do zig build run -- $f; done
+   for f in tests/*.dr; do zig build run -- "$f"; done
    ```
 
-### Windows
-
-1. **Install tools**: [Git for Windows](https://git-scm.com/) and [Zig](https://ziglang.org/download/). Ensure `zig` is available from the command prompt.
-
-2. **Clone the repository** using *Git Bash* or *Command Prompt*:
-
-   ```cmd
-   git clone https://github.com/Ddemon26/DreamCompiler.git
-   cd DreamCompiler
-   ```
-
-3. **Build the compiler**
-
-   ```cmd
-   zig build
-   ```
-
-4. **Compile and run the example**
-
-   ```cmd
-   zig build run -- example.dr
-   ```
-
-5. **Run the tests (optional)** using a simple loop in `cmd` or PowerShell.
-
-## Building
-
-Dream is built with Zig. The simplest approach is:
-
-```bash
-zig build
-```
-
-This places the `DreamCompiler` executable under `zig-out/bin`.
+The resulting compiler binary is placed under `zig-out/bin`.
 
 ## Using the Compiler
 
-Invoke the compiler with a `.dr` source file:
+Compile a `.dr` file directly:
 
 ```bash
 ./zig-out/bin/DreamCompiler path/to/file.dr
 ```
 
-The compiler writes `output.c` and compiles it into a runnable executable called `dream` in the current directory. Run the resulting program with:
+This writes `output.c` and builds a runnable program called `dream` in the current directory. Execute it with:
 
 ```bash
 ./dream
@@ -103,17 +58,13 @@ The compiler writes `output.c` and compiles it into a runnable executable called
 
 An example program is provided in [example.dr](example.dr).
 
-## Tests
-
-Simple language features are covered by tests in the [`tests`](tests) directory. After building the compiler, run each test file using `zig build run -- <file>` which will compile the test and execute the resulting program.
-
 ## Documentation
 
-Documentation for individual language features lives under [`docs`](docs). Start with [usage.md](docs/usage.md) for a high level overview.
+Documentation for language features lives under [`docs`](docs). Start with [usage.md](docs/usage.md) for an overview.
 
 ## Contributing
 
-Contributions are welcome. Please keep code style simple and document any new language feature under `docs/` with a matching test case under `tests/`. Install additional dependencies in [`codex/_startup.sh`](codex/_startup.sh) if required.
+Contributions are welcome. Document any new language feature under `docs/` with a matching test case in `tests/`. Add additional dependencies to [`codex/_startup.sh`](codex/_startup.sh) if required.
 
 ## License
 


### PR DESCRIPTION
## Summary
- streamline README instructions
- update Zig download links for Linux and Windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875947616b4832baca954de37c97a7d