### PR TITLE
Add documentation index with basic website styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ An example program is provided in [example.dr](example.dr).
 
 ## Documentation
 
-Documentation for language features lives under [`docs`](docs). Start with [usage.md](docs/v1/usage.md) for an overview.
+Documentation for language features lives under [`docs`](docs). Start with [index.md](docs/index.md) to browse the available guides.
 
 ## Contributing
 

--- a/docs/index.css
+++ b/docs/index.css
@@ -1,0 +1,21 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 1em;
+    line-height: 1.6;
+    background-color: #fdfdfd;
+}
+
+h1, h2 {
+    color: #333;
+}
+
+a {
+    color: #0066cc;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dream Compiler Docs</title>
+    <link rel="stylesheet" href="index.css">
+</head>
+<body>
+    <h1>Dream Compiler Documentation</h1>
+    <p>Welcome to the Dream language documentation. Select a topic below.</p>
+    <ul>
+        <li><a href="v1/usage.md">Usage Guide</a></li>
+        <li><a href="v1/variables.md">Variables</a></li>
+        <li><a href="v1/arithmetic.md">Arithmetic</a></li>
+        <li><a href="v1/console.md">Console Output</a></li>
+        <li><a href="v1/if.md">If Statements</a></li>
+        <li><a href="v1/loops.md">While Loops</a></li>
+        <li><a href="changelog.md">Changelog</a></li>
+    </ul>
+</body>
+</html>
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Dream Compiler Documentation
+
+Welcome to the documentation for the Dream language and compiler. The pages below describe the currently supported features and how to use them.
+
+## Guides
+
+- [Usage Guide](v1/usage.md)
+- [Variables](v1/variables.md)
+- [Arithmetic](v1/arithmetic.md)
+- [Console Output](v1/console.md)
+- [If Statements](v1/if.md)
+- [While Loops](v1/loops.md)
+- [Changelog](changelog.md)
+
+


### PR DESCRIPTION
## Summary
- add a docs index in markdown
- create a simple `index.html` and `index.css`
- link to the new docs index from the README

## Testing
- `zig build` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_687599122170832ba276e177f8a0526d