### PR TITLE
Update docs navigation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,3 +67,8 @@ Version 1.0.10 (2025-07-14)
 Version 1.0.11 (2025-07-14)
 
 * Documentation site now supports optional dark mode.
+
+Version 1.0.12 (2025-07-14)
+
+* Restructured documentation index with category submenus.
+* Added version selection dropdown.

--- a/docs/index-dark.css
+++ b/docs/index-dark.css
@@ -70,6 +70,32 @@ body {
     font-weight: bold;
 }
 
+.version-label {
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+    display: block;
+}
+
+#version-select {
+    margin-bottom: 1rem;
+    width: 100%;
+    padding: 0.25rem;
+    background-color: #333333;
+    color: #ffffff;
+    border: 1px solid #444444;
+}
+
+.nav li.category > span {
+    font-weight: bold;
+    display: block;
+    padding: 0.25rem 0;
+}
+
+.nav li.category ul {
+    margin-left: 1rem;
+    margin-top: 0.25rem;
+}
+
 .main-content {
     flex: 1;
     padding: 2rem;

--- a/docs/index.css
+++ b/docs/index.css
@@ -70,6 +70,29 @@ body {
     font-weight: bold;
 }
 
+.version-label {
+    font-size: 0.9rem;
+    margin-bottom: 0.25rem;
+    display: block;
+}
+
+#version-select {
+    margin-bottom: 1rem;
+    width: 100%;
+    padding: 0.25rem;
+}
+
+.nav li.category > span {
+    font-weight: bold;
+    display: block;
+    padding: 0.25rem 0;
+}
+
+.nav li.category ul {
+    margin-left: 1rem;
+    margin-top: 0.25rem;
+}
+
 .main-content {
     flex: 1;
     padding: 2rem;

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,14 +13,30 @@
     <aside class="sidebar">
         <nav class="nav">
             <h2>Documentation</h2>
+            <label for="version-select" class="version-label">Version:</label>
+            <select id="version-select">
+                <option value="v1" selected>v1</option>
+            </select>
             <ul>
-                <li><a href="#" data-md="v1/usage.md">Usage Guide</a></li>
-                <li><a href="#" data-md="v1/variables.md">Variables</a></li>
-                <li><a href="#" data-md="v1/arithmetic.md">Arithmetic</a></li>
-                <li><a href="#" data-md="v1/comparison.md">Comparison</a></li>
-                <li><a href="#" data-md="v1/console.md">Console Output</a></li>
-                <li><a href="#" data-md="v1/if.md">If Statements</a></li>
-                <li><a href="#" data-md="v1/loops.md">While Loops</a></li>
+                <li class="category"><span>Getting Started</span>
+                    <ul>
+                        <li><a href="#" data-md="usage.md">Usage Guide</a></li>
+                    </ul>
+                </li>
+                <li class="category"><span>Language Basics</span>
+                    <ul>
+                        <li><a href="#" data-md="variables.md">Variables</a></li>
+                        <li><a href="#" data-md="arithmetic.md">Arithmetic</a></li>
+                        <li><a href="#" data-md="comparison.md">Comparison</a></li>
+                        <li><a href="#" data-md="console.md">Console Output</a></li>
+                    </ul>
+                </li>
+                <li class="category"><span>Control Flow</span>
+                    <ul>
+                        <li><a href="#" data-md="if.md">If Statements</a></li>
+                        <li><a href="#" data-md="loops.md">While Loops</a></li>
+                    </ul>
+                </li>
                 <li><a href="#" data-md="changelog.md">Changelog</a></li>
             </ul>
         </nav>
@@ -40,6 +56,8 @@
         const navLinks = document.querySelectorAll('.nav a');
         const themeToggle = document.getElementById('theme-toggle');
         const themeLink = document.querySelector('link[rel="stylesheet"]');
+        const versionSelect = document.getElementById('version-select');
+        let currentVersion = versionSelect.value;
 
         // Apply saved theme
         if (localStorage.getItem('theme') === 'dark') {
@@ -59,16 +77,29 @@
             }
         }
 
+        function resolvePath(mdFile) {
+            if (mdFile.includes('/')) return mdFile;
+            return `${currentVersion}/${mdFile}`;
+        }
+
         // Handle nav link clicks
         navLinks.forEach(link => {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
                 const mdFile = link.getAttribute('data-md');
-                loadMarkdown(mdFile);
+                loadMarkdown(resolvePath(mdFile));
                 // Update active link
                 navLinks.forEach(l => l.classList.remove('active'));
                 link.classList.add('active');
             });
+        });
+
+        versionSelect.addEventListener('change', () => {
+            currentVersion = versionSelect.value;
+            const active = document.querySelector('.nav a.active');
+            if (active && active.dataset.md !== 'changelog.md') {
+                loadMarkdown(resolvePath(active.dataset.md));
+            }
         });
 
         // Toggle light/dark mode
@@ -86,10 +117,10 @@
         });
 
         // Load default page (optional: load usage.md by default)
-        const defaultLink = document.querySelector('.nav a[data-md="v1/usage.md"]');
+        const defaultLink = document.querySelector('.nav a[data-md="usage.md"]');
         if (defaultLink) {
             defaultLink.classList.add('active');
-            loadMarkdown('v1/usage.md');
+            loadMarkdown(resolvePath('usage.md'));
         }
     });
 </script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,13 +4,22 @@ Welcome to the documentation for the Dream language and compiler. The pages belo
 
 ## Guides
 
+Use the version dropdown in the sidebar to view documentation for other releases.
+
+### Getting Started
 - [Usage Guide](v1/usage.md)
+
+### Language Basics
 - [Variables](v1/variables.md)
 - [Arithmetic](v1/arithmetic.md)
 - [Comparison](v1/comparison.md)
 - [Console Output](v1/console.md)
+
+### Control Flow
 - [If Statements](v1/if.md)
 - [While Loops](v1/loops.md)
+
+### Other
 - [Changelog](changelog.md)
 
 


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Restructures the documentation index to support nested menu categories and allows selecting the documentation version via dropdown.

Related Files
Modified: `docs/index.html`
Modified: `docs/index.css`
Modified: `docs/index-dark.css`
Modified: `docs/index.md`
Modified: `docs/changelog.md`

Changes
- Added categories and version select elements in `index.html`
- Updated CSS styles to support new elements in both themes
- Adjusted JavaScript to load pages based on selected version
- Documented changes in `docs/index.md` and changelog

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
None

Documentation
- Updated `docs/index.html`, `docs/index.md`, stylesheets and `docs/changelog.md` with latest documentation navigation improvements.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
N/A

------
https://chatgpt.com/codex/tasks/task_e_6875a56f7744832b844e3e9d352d5b35