### PR TITLE
Fix build with Zig 0.15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,21 +4,28 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable(.{
-        .name = "DreamCompiler",
+    const module = b.createModule(.{
         .target = target,
         .optimize = optimize,
     });
 
-    exe.addCSourceFiles(&.{
-        "src/main.c",
-        "src/lexer.c",
-        "src/parser.c",
-        "src/codegen.c",
-    }, &.{
-        "-std=c11",
-        "-Wall",
-        "-Wextra",
+    const exe = b.addExecutable(.{
+        .name = "DreamCompiler",
+        .root_module = module,
+    });
+
+    exe.addCSourceFiles(.{
+        .files = &.{
+            "src/main.c",
+            "src/lexer.c",
+            "src/parser.c",
+            "src/codegen.c",
+        },
+        .flags = &.{
+            "-std=c11",
+            "-Wall",
+            "-Wextra",
+        },
     });
 
     exe.linkLibC();

--- a/codex/_startup.sh
+++ b/codex/_startup.sh
@@ -10,26 +10,33 @@ echo "Installing core dependencies..."
 sudo apt install -y build-essential curl
 
 echo "Installing Zig..."
-# Default to Zig 0.11 if ZIG_VERSION not provided
-ZIG_VERSION=${ZIG_VERSION:-0.11.0}
+# Default to Zig 0.15 if ZIG_VERSION not provided
+ZIG_VERSION=${ZIG_VERSION:-0.15.0-dev.1034+bd97b6618}
 ARCH=$(uname -m)
 case "$ARCH" in
     x86_64)
-        ZIG_ARCH="x86_64"
+        ZIG_ARCH="x86_64-linux"
         ;;
     aarch64)
-        ZIG_ARCH="aarch64"
+        ZIG_ARCH="aarch64-linux"
         ;;
     *)
         echo "Unsupported architecture: $ARCH" >&2
         exit 1
         ;;
 esac
-ZIG_DIR="zig-linux-${ZIG_ARCH}-${ZIG_VERSION}"
+ZIG_DIR="zig-${ZIG_ARCH}-${ZIG_VERSION}"
 ZIG_TAR="${ZIG_DIR}.tar.xz"
 
+# Determine base URL. Development builds are hosted under /builds
+if [[ "$ZIG_VERSION" == *"dev"* || "$ZIG_VERSION" == *"rc"* ]]; then
+    BASE_URL="https://ziglang.org/builds"
+else
+    BASE_URL="https://ziglang.org/download/${ZIG_VERSION}"
+fi
+
 # Fetch and install Zig from the official release archive
-curl -L "https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TAR}" -o "/tmp/${ZIG_TAR}"
+curl -L "${BASE_URL}/${ZIG_TAR}" -o "/tmp/${ZIG_TAR}"
 tar -C /tmp -xf "/tmp/${ZIG_TAR}"
 sudo mv "/tmp/${ZIG_DIR}" /usr/local/zig
 sudo ln -sf /usr/local/zig/zig /usr/local/bin/zig


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Updated build script for Zig 0.15.0-dev.1034+bd97b6618 and adjusted `build.zig` to the latest build API.

Related Files
Modified: `build.zig`
Modified: `codex/_startup.sh`

Changes
- use `createModule` and new `.addCSourceFiles` API in `build.zig`
- update `_startup.sh` to fetch Zig dev builds from `/builds` and default to version 0.15

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
Updated `_startup.sh` to install Zig 0.15 from the correct download path.

Documentation
No documentation changes were required.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [x] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_6875aade55ac832b93f4c97fd13991d4