### PR TITLE
Write generated C to build/bin/dream.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Compile a `.dr` file directly:
 ./zig-out/bin/DreamCompiler path/to/file.dr
 ```
 
-This writes `output.c` and builds a runnable program called `dream` in the current directory. Execute it with:
+This writes `build/bin/dream.c` and builds a runnable program called `dream` in the current directory. Execute it with:
 
 ```bash
 ./dream

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -90,3 +90,13 @@ Version 1.0.15 (2025-07-15)
 * Added modulo operator (%) for arithmetic expressions.
 * Updated documentation and usage guide.
 * Added regression test for modulo.
+
+Version 1.0.16 (2025-07-15)
+
+* Fixed compiler crash when output file directory was missing.
+  The generated C code now writes to `output.c` before compilation.
+
+Version 1.0.17 (2025-07-15)
+
+* Reverted to generating `build/bin/dream.c` so the C file lives inside
+  the build directory. The compilation command now matches this path.

--- a/src/main.c
+++ b/src/main.c
@@ -57,7 +57,7 @@
         if (!cc)
             cc = "gcc";
         char cmd[256];
-        snprintf(cmd, sizeof(cmd), "%s output.c -o build/bin/dream.exe", cc);
+        snprintf(cmd, sizeof(cmd), "%s build/bin/dream.c -o build/bin/dream.exe", cc);
         system(cmd);
         return 0;
     }


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Switched the compiler back to generating `build/bin/dream.c` instead of `output.c`. The compile command now references this location, and documentation has been updated.

Related Files
Modified: `src/main.c`
Modified: `docs/changelog.md`
Modified: `README.md`

Changes
- Output C file path restored to `build/bin/dream.c`
- Compilation command updated accordingly
- Documented this change in the changelog and usage guide

Testing
```bash
zig build
for f in tests/basic/*.dr tests/intermediate/*.dr tests/advanced/*.dr; do zig build run -- "$f"; done
```

Dependencies
No dependency changes required.

Documentation
- `docs/changelog.md` updated with version 1.0.17 entry
- Usage instructions in `README.md` updated

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None

------
https://chatgpt.com/codex/tasks/task_e_6875b281af18832b89b120bfa71b11e4