### PR TITLE
Implement else statements

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -100,3 +100,8 @@ Version 1.0.17 (2025-07-15)
 
 * Reverted to generating `build/bin/dream.c` so the C file lives inside
   the build directory. The compilation command now matches this path.
+
+Version 1.0.18 (2025-07-15)
+
+* Added `else` clauses to `if` statements.
+* Updated documentation and added a new test case.

--- a/docs/v1/if.md
+++ b/docs/v1/if.md
@@ -1,16 +1,17 @@
 If Statements in Dream
 ======================
 
-Dream now supports simple conditional execution using the `if` keyword.
+Dream supports conditional execution using the `if` keyword and an optional `else` clause.
 
 Syntax
 ------
 
 ```
 if (<expression>) <statement>
+else <statement>
 ```
 
-The condition can be a variable or number. Only one statement may follow the condition. Braces are optional but allowed for clarity.
+The `else` section is optional. Each branch may be a single statement or a statement enclosed in braces.
 
 Example
 -------
@@ -18,7 +19,7 @@ Example
 ```
 int x = 1;
 if (x) Console.WriteLine(x);
+else Console.WriteLine(0);
 ```
 
 This prints `1` because `x` is nonzero.
-

--- a/docs/v1/usage.md
+++ b/docs/v1/usage.md
@@ -9,7 +9,7 @@ Arithmetic: <identifier> = <expression> + <expression> or <expression> - <expres
 Comparison: <expression> < <expression> or <expression> > <expression> or <expression> <= <expression> or <expression> >= <expression> or <expression> == <expression> or <expression> != <expression>;
 Console Output: Console.WriteLine(<expression>);
     <expression> may be a variable, number, or quoted string.
-Conditional: if (<expression>) <statement>
+Conditional: if (<expression>) <statement> [else <statement>]
 Loop: while (<expression>) <statement>
 
 Example Program

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1,60 +1,64 @@
 #include "dream.h"
 #include <stdio.h>
 
-void gen_c_expr(FILE *out, Node *expr)
-{
-    if (!expr)
-        return;
-    if (expr->type == NODE_BINARY_OP) {
-        fputc('(', out);
-        gen_c_expr(out, expr->left);
-        fprintf(out, " %s ", expr->value);
-        gen_c_expr(out, expr->right);
-        fputc(')', out);
-    } else if (expr->type == NODE_IDENTIFIER ||
-               (expr->type == NODE_VAR_DECL && expr->left == NULL && expr->right == NULL)) {
-        fprintf(out, "%s", expr->value);
-    } else if (expr->type == NODE_NUMBER) {
-        fprintf(out, "%s", expr->value);
-    } else if (expr->type == NODE_STRING) {
-        fprintf(out, "\"%s\"", expr->value);
-    }
+void gen_c_expr(FILE *out, Node *expr) {
+  if (!expr)
+    return;
+  if (expr->type == NODE_BINARY_OP) {
+    fputc('(', out);
+    gen_c_expr(out, expr->left);
+    fprintf(out, " %s ", expr->value);
+    gen_c_expr(out, expr->right);
+    fputc(')', out);
+  } else if (expr->type == NODE_IDENTIFIER ||
+             (expr->type == NODE_VAR_DECL && expr->left == NULL &&
+              expr->right == NULL)) {
+    fprintf(out, "%s", expr->value);
+  } else if (expr->type == NODE_NUMBER) {
+    fprintf(out, "%s", expr->value);
+  } else if (expr->type == NODE_STRING) {
+    fprintf(out, "\"%s\"", expr->value);
+  }
 }
 
-void generate_c(Compiler *compiler, Node *node)
-{
-    FILE *out = compiler->output;
-    if (node->type == NODE_VAR_DECL) {
-        fprintf(out, "    long %s", node->value);
-        if (node->left) {
-            fprintf(out, " = ");
-            gen_c_expr(out, node->left);
-        }
-        fprintf(out, ";\n");
-    } else if (node->type == NODE_ASSIGN) {
-        fprintf(out, "    %s = ", node->value);
-        gen_c_expr(out, node->left);
-        fprintf(out, ";\n");
-    } else if (node->type == NODE_WRITELINE) {
-        if (node->left && node->left->type == NODE_STRING) {
-            fprintf(out, "    printf(\"%%s\\n\", ");
-        } else {
-            fprintf(out, "    printf(\"%%ld\\n\", ");
-        }
-        gen_c_expr(out, node->left);
-        fprintf(out, ");\n");
-    } else if (node->type == NODE_IF) {
-        fprintf(out, "    if (");
-        gen_c_expr(out, node->left);
-        fprintf(out, ") {\n");
-        generate_c(compiler, node->right);
-        fprintf(out, "    }\n");
-    } else if (node->type == NODE_WHILE) {
-        fprintf(out, "    while (");
-        gen_c_expr(out, node->left);
-        fprintf(out, ") {\n");
-        generate_c(compiler, node->right);
-        fprintf(out, "    }\n");
+void generate_c(Compiler *compiler, Node *node) {
+  FILE *out = compiler->output;
+  if (node->type == NODE_VAR_DECL) {
+    fprintf(out, "    long %s", node->value);
+    if (node->left) {
+      fprintf(out, " = ");
+      gen_c_expr(out, node->left);
     }
+    fprintf(out, ";\n");
+  } else if (node->type == NODE_ASSIGN) {
+    fprintf(out, "    %s = ", node->value);
+    gen_c_expr(out, node->left);
+    fprintf(out, ";\n");
+  } else if (node->type == NODE_WRITELINE) {
+    if (node->left && node->left->type == NODE_STRING) {
+      fprintf(out, "    printf(\"%%s\\n\", ");
+    } else {
+      fprintf(out, "    printf(\"%%ld\\n\", ");
+    }
+    gen_c_expr(out, node->left);
+    fprintf(out, ");\n");
+  } else if (node->type == NODE_IF) {
+    fprintf(out, "    if (");
+    gen_c_expr(out, node->left);
+    fprintf(out, ") {\n");
+    generate_c(compiler, node->right);
+    fprintf(out, "    }");
+    if (node->else_branch) {
+      fprintf(out, " else {\n");
+      generate_c(compiler, node->else_branch);
+      fprintf(out, "    }");
+    }
+    fprintf(out, "\n");
+  } else if (node->type == NODE_WHILE) {
+    fprintf(out, "    while (");
+    gen_c_expr(out, node->left);
+    fprintf(out, ") {\n");
+    generate_c(compiler, node->right);
+    fprintf(out, "    }\n");
+  }
 }
-

--- a/src/dream.h
+++ b/src/dream.h
@@ -8,52 +8,75 @@
 #include <string.h>
 
 typedef enum {
-    TOKEN_INT, TOKEN_IDENTIFIER, TOKEN_NUMBER, TOKEN_STRING,
-    TOKEN_PLUS, TOKEN_MINUS, TOKEN_STAR, TOKEN_SLASH, TOKEN_PERCENT,
-    TOKEN_LT, TOKEN_GT, TOKEN_LE, TOKEN_GE,
-    TOKEN_EQEQ, TOKEN_NEQ,
-    TOKEN_SEMICOLON, TOKEN_EQUALS, TOKEN_CONSOLE, TOKEN_DOT,
-    TOKEN_WRITELINE, TOKEN_LPAREN, TOKEN_RPAREN, TOKEN_IF, TOKEN_WHILE,
-    TOKEN_LBRACE, TOKEN_RBRACE,
-    TOKEN_EOF, TOKEN_UNKNOWN
+  TOKEN_INT,
+  TOKEN_IDENTIFIER,
+  TOKEN_NUMBER,
+  TOKEN_STRING,
+  TOKEN_PLUS,
+  TOKEN_MINUS,
+  TOKEN_STAR,
+  TOKEN_SLASH,
+  TOKEN_PERCENT,
+  TOKEN_LT,
+  TOKEN_GT,
+  TOKEN_LE,
+  TOKEN_GE,
+  TOKEN_EQEQ,
+  TOKEN_NEQ,
+  TOKEN_SEMICOLON,
+  TOKEN_EQUALS,
+  TOKEN_CONSOLE,
+  TOKEN_DOT,
+  TOKEN_WRITELINE,
+  TOKEN_LPAREN,
+  TOKEN_RPAREN,
+  TOKEN_IF,
+  TOKEN_ELSE,
+  TOKEN_WHILE,
+  TOKEN_LBRACE,
+  TOKEN_RBRACE,
+  TOKEN_EOF,
+  TOKEN_UNKNOWN
 } TokenType;
 
 typedef struct {
-    TokenType type;
-    char *value;
+  TokenType type;
+  char *value;
 } Token;
 
 typedef enum {
-    NODE_VAR_DECL,
-    NODE_ASSIGN,
-    NODE_WRITELINE,
-    NODE_BINARY_OP,
-    NODE_IF,
-    NODE_WHILE,
-    NODE_IDENTIFIER,
-    NODE_NUMBER,
-    NODE_STRING
+  NODE_VAR_DECL,
+  NODE_ASSIGN,
+  NODE_WRITELINE,
+  NODE_BINARY_OP,
+  NODE_IF,
+  NODE_WHILE,
+  NODE_IDENTIFIER,
+  NODE_NUMBER,
+  NODE_STRING
 } NodeType;
 
 typedef struct Node {
-    NodeType type;
-    char *value;
-    struct Node *left;
-    struct Node *right;
+  NodeType type;
+  char *value;
+  struct Node *left;
+  struct Node *right;
+  struct Node *else_branch;
 } Node;
 
 typedef struct {
-    char *source;
-    int pos;
-    int line;
+  char *source;
+  int pos;
+  int line;
 } Lexer;
 
 typedef struct {
-    FILE *output;
+  FILE *output;
 } Compiler;
 
 Token next_token(Lexer *lexer);
-Node *create_node(NodeType type, char *value, Node *left, Node *right);
+Node *create_node(NodeType type, char *value, Node *left, Node *right,
+                  Node *else_branch);
 Node *parse_expression(Lexer *lexer, Token *token);
 Node *parse_statement(Lexer *lexer, Token *token);
 void gen_c_expr(FILE *out, Node *expr);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -4,185 +4,187 @@
 #include <string.h>
 
 #ifdef _WIN32
-static char *strndup(const char *src, size_t n)
-{
-    size_t len = strlen(src);
-    if (n < len) len = n;
-    char *dest = malloc(len + 1);
-    if (!dest) return NULL;
-    memcpy(dest, src, len);
-    dest[len] = '\0';
-    return dest;
+static char *strndup(const char *src, size_t n) {
+  size_t len = strlen(src);
+  if (n < len)
+    len = n;
+  char *dest = malloc(len + 1);
+  if (!dest)
+    return NULL;
+  memcpy(dest, src, len);
+  dest[len] = '\0';
+  return dest;
 }
 #endif
 
-Token next_token(Lexer *lexer)
-{
-    while (isspace((unsigned char)lexer->source[lexer->pos]))
-        lexer->pos++;
+Token next_token(Lexer *lexer) {
+  while (isspace((unsigned char)lexer->source[lexer->pos]))
+    lexer->pos++;
 
-    if (lexer->source[lexer->pos] == '/' && lexer->source[lexer->pos + 1] == '/') {
-        while (lexer->source[lexer->pos] && lexer->source[lexer->pos] != '\n')
-            lexer->pos++;
-        return next_token(lexer);
-    }
+  if (lexer->source[lexer->pos] == '/' &&
+      lexer->source[lexer->pos + 1] == '/') {
+    while (lexer->source[lexer->pos] && lexer->source[lexer->pos] != '\n')
+      lexer->pos++;
+    return next_token(lexer);
+  }
 
-    Token token = {TOKEN_UNKNOWN, NULL};
-    if (lexer->source[lexer->pos] == '\0') {
-        token.type = TOKEN_EOF;
-        return token;
-    }
-
-    if (isalpha((unsigned char)lexer->source[lexer->pos])) {
-        int start = lexer->pos;
-        while (isalnum((unsigned char)lexer->source[lexer->pos]))
-            lexer->pos++;
-        int len = lexer->pos - start;
-        token.value = strndup(lexer->source + start, len);
-        if (strcmp(token.value, "int") == 0)
-            token.type = TOKEN_INT;
-        else if (strcmp(token.value, "Console") == 0)
-            token.type = TOKEN_CONSOLE;
-        else if (strcmp(token.value, "WriteLine") == 0)
-            token.type = TOKEN_WRITELINE;
-        else if (strcmp(token.value, "if") == 0)
-            token.type = TOKEN_IF;
-        else if (strcmp(token.value, "while") == 0)
-            token.type = TOKEN_WHILE;
-        else
-            token.type = TOKEN_IDENTIFIER;
-        return token;
-    }
-
-    if (lexer->source[lexer->pos] == '"') {
-        lexer->pos++; // skip opening quote
-        int start = lexer->pos;
-        while (lexer->source[lexer->pos] && lexer->source[lexer->pos] != '"')
-            lexer->pos++;
-        int len = lexer->pos - start;
-        token.value = strndup(lexer->source + start, len);
-        token.type = TOKEN_STRING;
-        if (lexer->source[lexer->pos] == '"')
-            lexer->pos++; // skip closing quote
-        return token;
-    }
-
-    if (isdigit((unsigned char)lexer->source[lexer->pos])) {
-        int start = lexer->pos;
-        while (isdigit((unsigned char)lexer->source[lexer->pos]))
-            lexer->pos++;
-        int len = lexer->pos - start;
-        token.value = strndup(lexer->source + start, len);
-        token.type = TOKEN_NUMBER;
-        return token;
-    }
-
-    switch (lexer->source[lexer->pos]) {
-    case '+':
-        token.type = TOKEN_PLUS;
-        token.value = strdup("+");
-        lexer->pos++;
-        break;
-    case '*':
-        token.type = TOKEN_STAR;
-        token.value = strdup("*");
-        lexer->pos++;
-        break;
-    case '/':
-        token.type = TOKEN_SLASH;
-        token.value = strdup("/");
-        lexer->pos++;
-        break;
-    case '%':
-        token.type = TOKEN_PERCENT;
-        token.value = strdup("%");
-        lexer->pos++;
-        break;
-    case '<':
-        if (lexer->source[lexer->pos + 1] == '=') {
-            token.type = TOKEN_LE;
-            token.value = strdup("<=");
-            lexer->pos += 2;
-        } else {
-            token.type = TOKEN_LT;
-            token.value = strdup("<");
-            lexer->pos++;
-        }
-        break;
-    case '>':
-        if (lexer->source[lexer->pos + 1] == '=') {
-            token.type = TOKEN_GE;
-            token.value = strdup(">=");
-            lexer->pos += 2;
-        } else {
-            token.type = TOKEN_GT;
-            token.value = strdup(">");
-            lexer->pos++;
-        }
-        break;
-    case '-':
-        token.type = TOKEN_MINUS;
-        token.value = strdup("-");
-        lexer->pos++;
-        break;
-    case ';':
-        token.type = TOKEN_SEMICOLON;
-        token.value = strdup(";");
-        lexer->pos++;
-        break;
-    case '=':
-        if (lexer->source[lexer->pos + 1] == '=') {
-            token.type = TOKEN_EQEQ;
-            token.value = strdup("==");
-            lexer->pos += 2;
-        } else {
-            token.type = TOKEN_EQUALS;
-            token.value = strdup("=");
-            lexer->pos++;
-        }
-        break;
-    case '!':
-        if (lexer->source[lexer->pos + 1] == '=') {
-            token.type = TOKEN_NEQ;
-            token.value = strdup("!=");
-            lexer->pos += 2;
-        } else {
-            token.type = TOKEN_UNKNOWN;
-            token.value = strndup(lexer->source + lexer->pos, 1);
-            lexer->pos++;
-        }
-        break;
-    case '.':
-        token.type = TOKEN_DOT;
-        token.value = strdup(".");
-        lexer->pos++;
-        break;
-    case '(':
-        token.type = TOKEN_LPAREN;
-        token.value = strdup("(");
-        lexer->pos++;
-        break;
-    case ')':
-        token.type = TOKEN_RPAREN;
-        token.value = strdup(")");
-        lexer->pos++;
-        break;
-    case '{':
-        token.type = TOKEN_LBRACE;
-        token.value = strdup("{");
-        lexer->pos++;
-        break;
-    case '}':
-        token.type = TOKEN_RBRACE;
-        token.value = strdup("}");
-        lexer->pos++;
-        break;
-    default:
-        token.type = TOKEN_UNKNOWN;
-        token.value = strndup(lexer->source + lexer->pos, 1);
-        lexer->pos++;
-        break;
-    }
+  Token token = {TOKEN_UNKNOWN, NULL};
+  if (lexer->source[lexer->pos] == '\0') {
+    token.type = TOKEN_EOF;
     return token;
-}
+  }
 
+  if (isalpha((unsigned char)lexer->source[lexer->pos])) {
+    int start = lexer->pos;
+    while (isalnum((unsigned char)lexer->source[lexer->pos]))
+      lexer->pos++;
+    int len = lexer->pos - start;
+    token.value = strndup(lexer->source + start, len);
+    if (strcmp(token.value, "int") == 0)
+      token.type = TOKEN_INT;
+    else if (strcmp(token.value, "Console") == 0)
+      token.type = TOKEN_CONSOLE;
+    else if (strcmp(token.value, "WriteLine") == 0)
+      token.type = TOKEN_WRITELINE;
+    else if (strcmp(token.value, "if") == 0)
+      token.type = TOKEN_IF;
+    else if (strcmp(token.value, "else") == 0)
+      token.type = TOKEN_ELSE;
+    else if (strcmp(token.value, "while") == 0)
+      token.type = TOKEN_WHILE;
+    else
+      token.type = TOKEN_IDENTIFIER;
+    return token;
+  }
+
+  if (lexer->source[lexer->pos] == '"') {
+    lexer->pos++; // skip opening quote
+    int start = lexer->pos;
+    while (lexer->source[lexer->pos] && lexer->source[lexer->pos] != '"')
+      lexer->pos++;
+    int len = lexer->pos - start;
+    token.value = strndup(lexer->source + start, len);
+    token.type = TOKEN_STRING;
+    if (lexer->source[lexer->pos] == '"')
+      lexer->pos++; // skip closing quote
+    return token;
+  }
+
+  if (isdigit((unsigned char)lexer->source[lexer->pos])) {
+    int start = lexer->pos;
+    while (isdigit((unsigned char)lexer->source[lexer->pos]))
+      lexer->pos++;
+    int len = lexer->pos - start;
+    token.value = strndup(lexer->source + start, len);
+    token.type = TOKEN_NUMBER;
+    return token;
+  }
+
+  switch (lexer->source[lexer->pos]) {
+  case '+':
+    token.type = TOKEN_PLUS;
+    token.value = strdup("+");
+    lexer->pos++;
+    break;
+  case '*':
+    token.type = TOKEN_STAR;
+    token.value = strdup("*");
+    lexer->pos++;
+    break;
+  case '/':
+    token.type = TOKEN_SLASH;
+    token.value = strdup("/");
+    lexer->pos++;
+    break;
+  case '%':
+    token.type = TOKEN_PERCENT;
+    token.value = strdup("%");
+    lexer->pos++;
+    break;
+  case '<':
+    if (lexer->source[lexer->pos + 1] == '=') {
+      token.type = TOKEN_LE;
+      token.value = strdup("<=");
+      lexer->pos += 2;
+    } else {
+      token.type = TOKEN_LT;
+      token.value = strdup("<");
+      lexer->pos++;
+    }
+    break;
+  case '>':
+    if (lexer->source[lexer->pos + 1] == '=') {
+      token.type = TOKEN_GE;
+      token.value = strdup(">=");
+      lexer->pos += 2;
+    } else {
+      token.type = TOKEN_GT;
+      token.value = strdup(">");
+      lexer->pos++;
+    }
+    break;
+  case '-':
+    token.type = TOKEN_MINUS;
+    token.value = strdup("-");
+    lexer->pos++;
+    break;
+  case ';':
+    token.type = TOKEN_SEMICOLON;
+    token.value = strdup(";");
+    lexer->pos++;
+    break;
+  case '=':
+    if (lexer->source[lexer->pos + 1] == '=') {
+      token.type = TOKEN_EQEQ;
+      token.value = strdup("==");
+      lexer->pos += 2;
+    } else {
+      token.type = TOKEN_EQUALS;
+      token.value = strdup("=");
+      lexer->pos++;
+    }
+    break;
+  case '!':
+    if (lexer->source[lexer->pos + 1] == '=') {
+      token.type = TOKEN_NEQ;
+      token.value = strdup("!=");
+      lexer->pos += 2;
+    } else {
+      token.type = TOKEN_UNKNOWN;
+      token.value = strndup(lexer->source + lexer->pos, 1);
+      lexer->pos++;
+    }
+    break;
+  case '.':
+    token.type = TOKEN_DOT;
+    token.value = strdup(".");
+    lexer->pos++;
+    break;
+  case '(':
+    token.type = TOKEN_LPAREN;
+    token.value = strdup("(");
+    lexer->pos++;
+    break;
+  case ')':
+    token.type = TOKEN_RPAREN;
+    token.value = strdup(")");
+    lexer->pos++;
+    break;
+  case '{':
+    token.type = TOKEN_LBRACE;
+    token.value = strdup("{");
+    lexer->pos++;
+    break;
+  case '}':
+    token.type = TOKEN_RBRACE;
+    token.value = strdup("}");
+    lexer->pos++;
+    break;
+  default:
+    token.type = TOKEN_UNKNOWN;
+    token.value = strndup(lexer->source + lexer->pos, 1);
+    lexer->pos++;
+    break;
+  }
+  return token;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1,63 +1,66 @@
 #include "dream.h"
-    #include <stdio.h>
-    #include <stdlib.h>
-    #include <string.h>
-    #ifdef _WIN32
-    #include <direct.h>
-    #else
-    #include <sys/stat.h>
-    #endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
 
-    int main(int argc, char *argv[])
-    {
-        if (argc != 2) {
-            fprintf(stderr, "Usage: %s <input.dr>\n", argv[0]);
-            return 1;
-        }
-        FILE *file = fopen(argv[1], "r");
-        if (!file) {
-            fprintf(stderr, "Cannot open file %s\n", argv[1]);
-            return 1;
-        }
-        fseek(file, 0, SEEK_END);
-        long size = ftell(file);
-        fseek(file, 0, SEEK_SET);
-        char *source = malloc(size + 1);
-        fread(source, 1, size, file);
-        source[size] = '\0';
-        fclose(file);
-        Lexer lexer = {source, 0, 1};
-        if ((unsigned char)source[0] == 0xEF && (unsigned char)source[1] == 0xBB &&
-            (unsigned char)source[2] == 0xBF) {
-            lexer.pos = 3;
-        }
-        Compiler compiler = {fopen("build/bin/dream.c", "w")};
-        fprintf(compiler.output, "#include <stdio.h>\n");
-        fprintf(compiler.output, "int main() {\n");
-        Token token = next_token(&lexer);
-        while (token.type != TOKEN_EOF) {
-            Node *node = parse_statement(&lexer, &token);
-            generate_c(&compiler, node);
-            free_node(node);
-            token = next_token(&lexer);
-        }
-        fprintf(compiler.output, "    return 0;\n");
-        fprintf(compiler.output, "}\n");
-        fclose(compiler.output);
-        free(source);
-        free(token.value);
-    #ifdef _WIN32
-        _mkdir("build");
-        _mkdir("build/bin");
-    #else
-        mkdir("build", 0755);
-        mkdir("build/bin", 0755);
-    #endif
-        const char *cc = getenv("CC");
-        if (!cc)
-            cc = "gcc";
-        char cmd[256];
-        snprintf(cmd, sizeof(cmd), "%s build/bin/dream.c -o build/bin/dream.exe", cc);
-        system(cmd);
-        return 0;
-    }
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    fprintf(stderr, "Usage: %s <input.dr>\n", argv[0]);
+    return 1;
+  }
+  FILE *file = fopen(argv[1], "r");
+  if (!file) {
+    fprintf(stderr, "Cannot open file %s\n", argv[1]);
+    return 1;
+  }
+  fseek(file, 0, SEEK_END);
+  long size = ftell(file);
+  fseek(file, 0, SEEK_SET);
+  char *source = malloc(size + 1);
+  fread(source, 1, size, file);
+  source[size] = '\0';
+  fclose(file);
+  Lexer lexer = {source, 0, 1};
+  if ((unsigned char)source[0] == 0xEF && (unsigned char)source[1] == 0xBB &&
+      (unsigned char)source[2] == 0xBF) {
+    lexer.pos = 3;
+  }
+#ifdef _WIN32
+  _mkdir("build");
+  _mkdir("build/bin");
+#else
+  mkdir("build", 0755);
+  mkdir("build/bin", 0755);
+#endif
+  Compiler compiler = {fopen("build/bin/dream.c", "w")};
+  if (!compiler.output) {
+    fprintf(stderr, "Failed to open output file\n");
+    return 1;
+  }
+  fprintf(compiler.output, "#include <stdio.h>\n");
+  fprintf(compiler.output, "int main() {\n");
+  Token token = next_token(&lexer);
+  while (token.type != TOKEN_EOF) {
+    Node *node = parse_statement(&lexer, &token);
+    generate_c(&compiler, node);
+    free_node(node);
+    token = next_token(&lexer);
+  }
+  fprintf(compiler.output, "    return 0;\n");
+  fprintf(compiler.output, "}\n");
+  fclose(compiler.output);
+  free(source);
+  free(token.value);
+  const char *cc = getenv("CC");
+  if (!cc)
+    cc = "gcc";
+  char cmd[256];
+  snprintf(cmd, sizeof(cmd), "%s build/bin/dream.c -o build/bin/dream.exe", cc);
+  system(cmd);
+  return 0;
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -3,212 +3,266 @@
 #include <stdlib.h>
 #include <string.h>
 
-Node *create_node(NodeType type, char *value, Node *left, Node *right)
-{
-    Node *node = malloc(sizeof(Node));
-    node->type = type;
-    node->value = value ? strdup(value) : NULL;
-    node->left = left;
-    node->right = right;
-    return node;
+Node *create_node(NodeType type, char *value, Node *left, Node *right,
+                  Node *else_branch) {
+  Node *node = malloc(sizeof(Node));
+  node->type = type;
+  node->value = value ? strdup(value) : NULL;
+  node->left = left;
+  node->right = right;
+  node->else_branch = else_branch;
+  return node;
 }
 
-Node *parse_expression(Lexer *lexer, Token *token)
-{
+Node *parse_expression(Lexer *lexer, Token *token) {
+  if (token->type != TOKEN_IDENTIFIER && token->type != TOKEN_NUMBER &&
+      token->type != TOKEN_STRING) {
+    fprintf(stderr, "Expected identifier, number or string\n");
+    exit(1);
+  }
+  NodeType left_type = NODE_IDENTIFIER;
+  if (token->type == TOKEN_NUMBER)
+    left_type = NODE_NUMBER;
+  else if (token->type == TOKEN_STRING)
+    left_type = NODE_STRING;
+  Node *left = create_node(left_type, token->value, NULL, NULL, NULL);
+  *token = next_token(lexer);
+  if ((token->type == TOKEN_PLUS || token->type == TOKEN_MINUS ||
+       token->type == TOKEN_STAR || token->type == TOKEN_SLASH ||
+       token->type == TOKEN_PERCENT || token->type == TOKEN_LT ||
+       token->type == TOKEN_GT || token->type == TOKEN_LE ||
+       token->type == TOKEN_GE || token->type == TOKEN_EQEQ ||
+       token->type == TOKEN_NEQ) &&
+      left_type != NODE_STRING) {
+    char *op = token->value;
+    *token = next_token(lexer);
+    if (token->type != TOKEN_IDENTIFIER && token->type != TOKEN_NUMBER) {
+      fprintf(stderr, "Expected identifier or number after %s\n", op);
+      exit(1);
+    }
+    Node *right = create_node(token->type == TOKEN_IDENTIFIER ? NODE_IDENTIFIER
+                                                              : NODE_NUMBER,
+                              token->value, NULL, NULL, NULL);
+    *token = next_token(lexer);
+    return create_node(NODE_BINARY_OP, op, left, right, NULL);
+  }
+  return left;
+}
+
+Node *parse_statement(Lexer *lexer, Token *token) {
+  if (token->type == TOKEN_INT) {
+    free(token->value);
+    *token = next_token(lexer);
+    if (token->type != TOKEN_IDENTIFIER) {
+      fprintf(stderr, "Expected identifier after int\n");
+      exit(1);
+    }
+    char *var_name = token->value;
+    *token = next_token(lexer);
+    Node *init = NULL;
+    if (token->type == TOKEN_EQUALS) {
+      free(token->value);
+      *token = next_token(lexer);
+      init = parse_expression(lexer, token);
+    }
+    if (token->type != TOKEN_SEMICOLON) {
+      fprintf(stderr, "Expected semicolon\n");
+      exit(1);
+    }
+    return create_node(NODE_VAR_DECL, var_name, init, NULL, NULL);
+  } else if (token->type == TOKEN_IDENTIFIER) {
+    char *var_name = token->value;
+    *token = next_token(lexer);
+    if (token->type == TOKEN_EQUALS) {
+      free(token->value);
+      *token = next_token(lexer);
+      Node *expr = parse_expression(lexer, token);
+      if (token->type != TOKEN_SEMICOLON) {
+        fprintf(stderr, "Expected semicolon\n");
+        exit(1);
+      }
+      return create_node(NODE_ASSIGN, var_name, expr, NULL, NULL);
+    }
+  } else if (token->type == TOKEN_CONSOLE) {
+    free(token->value);
+    *token = next_token(lexer);
+    if (token->type != TOKEN_DOT) {
+      fprintf(stderr, "Expected dot after Console\n");
+      exit(1);
+    }
+    free(token->value);
+    *token = next_token(lexer);
+    if (token->type != TOKEN_WRITELINE) {
+      fprintf(stderr, "Expected WriteLine\n");
+      exit(1);
+    }
+    free(token->value);
+    *token = next_token(lexer);
+    if (token->type != TOKEN_LPAREN) {
+      fprintf(stderr, "Expected (\n");
+      exit(1);
+    }
+    free(token->value);
+    *token = next_token(lexer);
     if (token->type != TOKEN_IDENTIFIER && token->type != TOKEN_NUMBER &&
         token->type != TOKEN_STRING) {
-        fprintf(stderr, "Expected identifier, number or string\n");
-        exit(1);
+      fprintf(stderr, "Expected identifier, number or string\n");
+      exit(1);
     }
-    NodeType left_type = NODE_IDENTIFIER;
+    NodeType arg_type = NODE_IDENTIFIER;
     if (token->type == TOKEN_NUMBER)
-        left_type = NODE_NUMBER;
+      arg_type = NODE_NUMBER;
     else if (token->type == TOKEN_STRING)
-        left_type = NODE_STRING;
-    Node *left = create_node(left_type, token->value, NULL, NULL);
+      arg_type = NODE_STRING;
+    Node *arg = create_node(arg_type, token->value, NULL, NULL, NULL);
     *token = next_token(lexer);
-    if ((token->type == TOKEN_PLUS || token->type == TOKEN_MINUS ||
-         token->type == TOKEN_STAR || token->type == TOKEN_SLASH || token->type == TOKEN_PERCENT ||
-         token->type == TOKEN_LT || token->type == TOKEN_GT ||
-         token->type == TOKEN_LE || token->type == TOKEN_GE ||
-         token->type == TOKEN_EQEQ || token->type == TOKEN_NEQ) &&
-        left_type != NODE_STRING) {
-        char *op = token->value;
-        *token = next_token(lexer);
-        if (token->type != TOKEN_IDENTIFIER && token->type != TOKEN_NUMBER) {
-            fprintf(stderr, "Expected identifier or number after %s\n", op);
-            exit(1);
-        }
-        Node *right = create_node(token->type == TOKEN_IDENTIFIER ? NODE_IDENTIFIER : NODE_NUMBER,
-                                  token->value, NULL, NULL);
-        *token = next_token(lexer);
-        return create_node(NODE_BINARY_OP, op, left, right);
+    if (token->type != TOKEN_RPAREN) {
+      fprintf(stderr, "Expected )\n");
+      exit(1);
     }
-    return left;
-}
-
-Node *parse_statement(Lexer *lexer, Token *token)
-{
-    if (token->type == TOKEN_INT) {
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_IDENTIFIER) {
-            fprintf(stderr, "Expected identifier after int\n");
-            exit(1);
-        }
-        char *var_name = token->value;
-        *token = next_token(lexer);
-        Node *init = NULL;
-        if (token->type == TOKEN_EQUALS) {
-            free(token->value);
-            *token = next_token(lexer);
-            init = parse_expression(lexer, token);
-        }
-        if (token->type != TOKEN_SEMICOLON) {
-            fprintf(stderr, "Expected semicolon\n");
-            exit(1);
-        }
-        return create_node(NODE_VAR_DECL, var_name, init, NULL);
-    } else if (token->type == TOKEN_IDENTIFIER) {
-        char *var_name = token->value;
-        *token = next_token(lexer);
-        if (token->type == TOKEN_EQUALS) {
-            free(token->value);
-            *token = next_token(lexer);
-            Node *expr = parse_expression(lexer, token);
-            if (token->type != TOKEN_SEMICOLON) {
-                fprintf(stderr, "Expected semicolon\n");
-                exit(1);
-            }
-            return create_node(NODE_ASSIGN, var_name, expr, NULL);
-        }
-    } else if (token->type == TOKEN_CONSOLE) {
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_DOT) {
-            fprintf(stderr, "Expected dot after Console\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_WRITELINE) {
-            fprintf(stderr, "Expected WriteLine\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_LPAREN) {
-            fprintf(stderr, "Expected (\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_IDENTIFIER && token->type != TOKEN_NUMBER &&
-            token->type != TOKEN_STRING) {
-            fprintf(stderr, "Expected identifier, number or string\n");
-            exit(1);
-        }
-        NodeType arg_type = NODE_IDENTIFIER;
-        if (token->type == TOKEN_NUMBER)
-            arg_type = NODE_NUMBER;
-        else if (token->type == TOKEN_STRING)
-            arg_type = NODE_STRING;
-        Node *arg = create_node(arg_type, token->value, NULL, NULL);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_RPAREN) {
-            fprintf(stderr, "Expected )\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_SEMICOLON) {
-            fprintf(stderr, "Expected semicolon\n");
-            exit(1);
-        }
-        return create_node(NODE_WRITELINE, NULL, arg, NULL);
-    } else if (token->type == TOKEN_IF) {
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_LPAREN) {
-            fprintf(stderr, "Expected ( after if\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        Node *cond = parse_expression(lexer, token);
-        if (token->type != TOKEN_RPAREN) {
-            fprintf(stderr, "Expected ) after condition\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        Node *body = NULL;
-        if (token->type == TOKEN_LBRACE) {
-            free(token->value);
-            *token = next_token(lexer);
-            body = parse_statement(lexer, token);
-            if (token->type != TOKEN_SEMICOLON) {
-                fprintf(stderr, "Expected semicolon\n");
-                exit(1);
-            }
-            free(token->value);
-            *token = next_token(lexer);
-            if (token->type != TOKEN_RBRACE) {
-                fprintf(stderr, "Expected } after if body\n");
-                exit(1);
-            }
-        } else {
-            body = parse_statement(lexer, token);
-        }
-        return create_node(NODE_IF, NULL, cond, body);
-    } else if (token->type == TOKEN_WHILE) {
-        free(token->value);
-        *token = next_token(lexer);
-        if (token->type != TOKEN_LPAREN) {
-            fprintf(stderr, "Expected ( after while\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        Node *cond = parse_expression(lexer, token);
-        if (token->type != TOKEN_RPAREN) {
-            fprintf(stderr, "Expected ) after condition\n");
-            exit(1);
-        }
-        free(token->value);
-        *token = next_token(lexer);
-        Node *body = NULL;
-        if (token->type == TOKEN_LBRACE) {
-            free(token->value);
-            *token = next_token(lexer);
-            body = parse_statement(lexer, token);
-            if (token->type != TOKEN_SEMICOLON) {
-                fprintf(stderr, "Expected semicolon\n");
-                exit(1);
-            }
-            free(token->value);
-            *token = next_token(lexer);
-            if (token->type != TOKEN_RBRACE) {
-                fprintf(stderr, "Expected } after while body\n");
-                exit(1);
-            }
-        } else {
-            body = parse_statement(lexer, token);
-        }
-        return create_node(NODE_WHILE, NULL, cond, body);
+    free(token->value);
+    *token = next_token(lexer);
+    if (token->type != TOKEN_SEMICOLON) {
+      fprintf(stderr, "Expected semicolon\n");
+      exit(1);
     }
-    fprintf(stderr, "Invalid statement\n");
-    exit(1);
+    return create_node(NODE_WRITELINE, NULL, arg, NULL, NULL);
+  } else if (token->type == TOKEN_IF) {
+    free(token->value);
+    *token = next_token(lexer);
+    if (token->type != TOKEN_LPAREN) {
+      fprintf(stderr, "Expected ( after if\n");
+      exit(1);
+    }
+    free(token->value);
+    *token = next_token(lexer);
+    Node *cond = parse_expression(lexer, token);
+    if (token->type != TOKEN_RPAREN) {
+      fprintf(stderr, "Expected ) after condition\n");
+      exit(1);
+    }
+    free(token->value);
+    *token = next_token(lexer);
+    Node *body = NULL;
+    Node *else_body = NULL;
+    if (token->type == TOKEN_LBRACE) {
+      free(token->value);
+      *token = next_token(lexer);
+      body = parse_statement(lexer, token);
+      if (token->type != TOKEN_SEMICOLON) {
+        fprintf(stderr, "Expected semicolon\n");
+        exit(1);
+      }
+      free(token->value);
+      *token = next_token(lexer);
+      if (token->type != TOKEN_RBRACE) {
+        fprintf(stderr, "Expected } after if body\n");
+        exit(1);
+      }
+      Token end_token = *token;
+      int saved_pos = lexer->pos;
+      *token = next_token(lexer);
+      if (token->type != TOKEN_ELSE) {
+        free(token->value);
+        *token = end_token;
+        lexer->pos = saved_pos;
+      } else {
+        free(end_token.value);
+      }
+    } else {
+      body = parse_statement(lexer, token);
+      if (token->type != TOKEN_SEMICOLON) {
+        fprintf(stderr, "Expected semicolon\n");
+        exit(1);
+      }
+      Token end_token = *token;
+      int saved_pos = lexer->pos;
+      *token = next_token(lexer);
+      if (token->type != TOKEN_ELSE) {
+        free(token->value);
+        *token = end_token;
+        lexer->pos = saved_pos;
+      } else {
+        free(end_token.value);
+      }
+    }
+    if (token->type == TOKEN_ELSE) {
+      free(token->value);
+      *token = next_token(lexer);
+      if (token->type == TOKEN_LBRACE) {
+        free(token->value);
+        *token = next_token(lexer);
+        else_body = parse_statement(lexer, token);
+        if (token->type != TOKEN_SEMICOLON) {
+          fprintf(stderr, "Expected semicolon\n");
+          exit(1);
+        }
+        free(token->value);
+        *token = next_token(lexer);
+        if (token->type != TOKEN_RBRACE) {
+          fprintf(stderr, "Expected } after else body\n");
+          exit(1);
+        }
+        free(token->value);
+        *token = next_token(lexer);
+      } else {
+        else_body = parse_statement(lexer, token);
+        if (token->type != TOKEN_SEMICOLON) {
+          fprintf(stderr, "Expected semicolon\n");
+          exit(1);
+        }
+        free(token->value);
+        *token = next_token(lexer);
+      }
+    }
+    return create_node(NODE_IF, NULL, cond, body, else_body);
+  } else if (token->type == TOKEN_WHILE) {
+    free(token->value);
+    *token = next_token(lexer);
+    if (token->type != TOKEN_LPAREN) {
+      fprintf(stderr, "Expected ( after while\n");
+      exit(1);
+    }
+    free(token->value);
+    *token = next_token(lexer);
+    Node *cond = parse_expression(lexer, token);
+    if (token->type != TOKEN_RPAREN) {
+      fprintf(stderr, "Expected ) after condition\n");
+      exit(1);
+    }
+    free(token->value);
+    *token = next_token(lexer);
+    Node *body = NULL;
+    if (token->type == TOKEN_LBRACE) {
+      free(token->value);
+      *token = next_token(lexer);
+      body = parse_statement(lexer, token);
+      if (token->type != TOKEN_SEMICOLON) {
+        fprintf(stderr, "Expected semicolon\n");
+        exit(1);
+      }
+      free(token->value);
+      *token = next_token(lexer);
+      if (token->type != TOKEN_RBRACE) {
+        fprintf(stderr, "Expected } after while body\n");
+        exit(1);
+      }
+    } else {
+      body = parse_statement(lexer, token);
+    }
+    return create_node(NODE_WHILE, NULL, cond, body, NULL);
+  }
+  fprintf(stderr, "Invalid statement\n");
+  exit(1);
 }
 
-void free_node(Node *n)
-{
-    if (!n)
-        return;
-    if (n->value)
-        free(n->value);
-    free_node(n->left);
-    free_node(n->right);
-    free(n);
+void free_node(Node *n) {
+  if (!n)
+    return;
+  if (n->value)
+    free(n->value);
+  free_node(n->left);
+  free_node(n->right);
+  free_node(n->else_branch);
+  free(n);
 }
-

--- a/tests/intermediate/if_else.dr
+++ b/tests/intermediate/if_else.dr
@@ -1,0 +1,3 @@
+int x = 0;
+if (x) Console.WriteLine(1);
+else Console.WriteLine(2);


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added support for optional `else` clauses on `if` statements. Documentation was updated and a new test demonstrates the feature.

Related Files
Modified: `src/lexer.c`, `src/parser.c`, `src/codegen.c`, `src/dream.h`, `src/main.c`
Added: `tests/intermediate/if_else.dr`
Modified: `docs/v1/if.md`, `docs/v1/usage.md`, `docs/changelog.md`

Changes
- Lexer recognizes `else` keyword.
- Parser handles optional `else` blocks and AST nodes now include `else_branch`.
- Code generator outputs C `else` blocks.
- Main program creates output directory before opening the C file.
- Documentation updated to describe `else` clauses.

Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done`

Dependencies
- None

Documentation
- Updated `docs/v1/if.md` and `docs/v1/usage.md`.
- Recorded in `docs/changelog.md`.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_6875b74ed4d0832b8cd10cb96fced838