### PR TITLE
Improve documentation index and add intro

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,7 @@
             <ul>
                 <li class="category"><span>Getting Started</span>
                     <ul>
+                        <li><a href="#" data-md="intro.md">Introduction</a></li>
                         <li><a href="#" data-md="usage.md">Usage Guide</a></li>
                     </ul>
                 </li>
@@ -27,6 +28,7 @@
                     <ul>
                         <li><a href="#" data-md="variables.md">Variables</a></li>
                         <li><a href="#" data-md="arithmetic.md">Arithmetic</a></li>
+                        <li><a href="#" data-md="parentheses.md">Parentheses</a></li>
                         <li><a href="#" data-md="comparison.md">Comparison</a></li>
                         <li><a href="#" data-md="console.md">Console Output</a></li>
                     </ul>
@@ -38,6 +40,7 @@
                     </ul>
                 </li>
                 <li><a href="#" data-md="changelog.md">Changelog</a></li>
+                <li><a href="#" data-md="architecture.md">Source Architecture</a></li>
             </ul>
         </nav>
     </aside>
@@ -125,11 +128,11 @@
             }
         });
 
-        // Load default page (optional: load usage.md by default)
-        const defaultLink = document.querySelector('.nav a[data-md="usage.md"]');
+        // Load default page (intro.md by default)
+        const defaultLink = document.querySelector('.nav a[data-md="intro.md"]');
         if (defaultLink) {
             defaultLink.classList.add('active');
-            loadMarkdown(resolvePath('usage.md'));
+            loadMarkdown(resolvePath('intro.md'));
             // Open the "Getting Started" category by default
             const gettingStarted = document.querySelector('.category:first-child');
             if (gettingStarted) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Welcome to the documentation for the Dream language and compiler. The pages belo
 Use the version dropdown in the sidebar to view documentation for other releases.
 
 ### Getting Started
+- [Introduction](v1/intro.md)
 - [Usage Guide](v1/usage.md)
 
 ### Language Basics

--- a/docs/v1/architecture.md
+++ b/docs/v1/architecture.md
@@ -1,5 +1,4 @@
-Dream Compiler Architecture
-===========================
+# Dream Compiler Architecture
 
 This document describes the layout of the `src/` directory and ways to avoid monolithic "god" files.
 
@@ -27,3 +26,4 @@ src/
 ```
 
 Dividing the code this way keeps each component focused and reduces the risk of oversized modules.
+

--- a/docs/v1/arithmetic.md
+++ b/docs/v1/arithmetic.md
@@ -1,29 +1,31 @@
-Arithmetic in Dream
-Overview
-Dream supports basic arithmetic operations. Addition (+) was the first
-operator implemented and subtraction (-) is now also available. Multiplication
+# Arithmetic in Dream
+
+## Overview
+Dream supports basic arithmetic operations. Addition (`+`) was the first
+operator implemented and subtraction (`-`) is now also available. Multiplication
 using the `*` operator has been introduced as well. Division with the `/`
-operator is now supported. Modulo with the `%` operator is now available as well.
-Syntax
+operator is now supported. Modulo with the `%` operator is now available too.
 
-Addition: <identifier> = <expression> + <expression>;
-Adds two expressions (variables or numbers) and assigns the result.
+## Syntax
 
-Subtraction: <identifier> = <expression> - <expression>;
-Subtracts the right expression from the left expression.
+**Addition**: `<identifier> = <expression> + <expression>;`
+: Adds two expressions (variables or numbers) and assigns the result.
 
-Multiplication: <identifier> = <expression> * <expression>;
-Multiplies two expressions together and assigns the result.
+**Subtraction**: `<identifier> = <expression> - <expression>;`
+: Subtracts the right expression from the left expression.
 
-Division: <identifier> = <expression> / <expression>;
-Divides the left expression by the right expression and assigns the result.
+**Multiplication**: `<identifier> = <expression> * <expression>;`
+: Multiplies two expressions together and assigns the result.
 
-Modulo: <identifier> = <expression> % <expression>;
-Stores the remainder of dividing the left expression by the right.
+**Division**: `<identifier> = <expression> / <expression>;`
+: Divides the left expression by the right expression and assigns the result.
 
+**Modulo**: `<identifier> = <expression> % <expression>;`
+: Stores the remainder of dividing the left expression by the right.
 
+## Examples
 
-Examples
+```dream
 int x = 5;
 int y = 10;
 x = y + 5;   // x = 15
@@ -31,10 +33,11 @@ x = y - 3;   // x = 7
 x = y * 2;   // x = 20
 x = y / 5;   // x = 2
 x = y % 4;   // x = 2
+```
 
-Notes
+## Notes
 
 Operands can be variables or literal numbers.
-Result is stored in the left-hand variable.
+The result is stored in the left-hand variable.
 Negative numbers can be written by prefixing a value with `-`, e.g. `int x = -5;`.
 Parentheses may be used to group sub-expressions, e.g. `int x = (2 + 3) * 4;`.

--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -1,4 +1,4 @@
-Dream Compiler Changelog
+# Dream Compiler Changelog
 Version 1.0.1 (2025-07-14)
 
 Initial compiler implementation in dream.c.
@@ -120,3 +120,4 @@ Version 1.0.21 (2025-07-15)
 
 * Braced blocks can now contain multiple statements in `if` and `while`.
 * Updated documentation and added regression tests.
+

--- a/docs/v1/comparison.md
+++ b/docs/v1/comparison.md
@@ -1,5 +1,4 @@
-Comparison Operators in Dream
-=============================
+# Comparison Operators in Dream
 
 Dream now supports comparison and equality operators for building conditions.
 
@@ -26,4 +25,5 @@ int x = 5;
 int y = 5;
 if (x == y) Console.WriteLine(x); // prints 5
 ```
+
 

--- a/docs/v1/console.md
+++ b/docs/v1/console.md
@@ -1,19 +1,23 @@
-Console Output in Dream
-Overview
-Dream provides Console.WriteLine for outputting values to the console, similar to C#.
-Syntax
+# Console Output in Dream
 
-Output: Console.WriteLine(<expression>);
-Prints the value of a variable, number, or quoted string.
+## Overview
+Dream provides `Console.WriteLine` for outputting values to the console, similar to C#.
 
+## Syntax
 
+`Console.WriteLine(<expression>);`
+: Prints the value of a variable, number or quoted string.
 
-Examples
+## Examples
+
+```dream
 int x = 15;
 Console.WriteLine(x);          // Outputs 15
 Console.WriteLine("hello");   // Outputs the string "hello"
+```
 
-Notes
+## Notes
 
-Console.WriteLine now prints integers using printf so the output appears in
+`Console.WriteLine` prints integers using `printf` so the output appears in
 decimal form. Strings are emitted directly as C string literals.
+

--- a/docs/v1/if.md
+++ b/docs/v1/if.md
@@ -1,5 +1,4 @@
-If Statements in Dream
-======================
+# If Statements in Dream
 
 Dream supports conditional execution using the `if` keyword and an optional `else` clause.
 
@@ -27,3 +26,4 @@ if (x) {
 ```
 
 This prints `1` because `x` is nonzero.
+

--- a/docs/v1/intro.md
+++ b/docs/v1/intro.md
@@ -1,0 +1,12 @@
+# Introduction to Dream
+
+Dream is a small experimental programming language with C#-like syntax. The Dream compiler translates `.dr` files into C code which is then built into an executable using Zig.
+
+This short guide explains the purpose of Dream and points you to the rest of the documentation for details on each language feature.
+
+- Dream aims to be easy to read with semicolon-terminated statements.
+- Only integers are supported so far, but more types are planned.
+- Control flow includes `if` statements and `while` loops with braced blocks.
+
+Use the sidebar or the table of contents to explore specific topics such as variables, arithmetic and comparison operators.
+

--- a/docs/v1/loops.md
+++ b/docs/v1/loops.md
@@ -1,5 +1,4 @@
-Loops in Dream
-===============
+# Loops in Dream
 
 Dream now supports basic looping using the `while` keyword.
 
@@ -10,7 +9,7 @@ Syntax
 while (<expression>) <statement>
 ```
 
-The loop executes the statement repeatedly while the expression evaluates to a nonzero value. Braces may surround the body and may now contain multiple statements separated by semicolons.
+The loop executes the statement repeatedly while the expression evaluates to a nonzero value. Braces may surround the body and may contain multiple statements separated by semicolons.
 
 Example
 -------
@@ -22,5 +21,6 @@ while (i) {
     i = i - 1;
 }
 ```
+
 
 

--- a/docs/v1/parentheses.md
+++ b/docs/v1/parentheses.md
@@ -1,5 +1,4 @@
-Parentheses in Dream
-====================
+# Parentheses in Dream
 
 Dream allows grouping expressions with parentheses to control evaluation order.
 
@@ -19,3 +18,4 @@ Example
 int x = (2 + 3) * 4;
 Console.WriteLine(x); // Outputs 20
 ```
+

--- a/docs/v1/usage.md
+++ b/docs/v1/usage.md
@@ -1,7 +1,9 @@
-Dream Language Usage Guide
-Overview
-Dream is a programming language with C#-like, semicolon-based syntax, compiled to C code. This guide covers the current syntax and usage.
-Syntax
+# Dream Language Usage Guide
+
+## Overview
+Dream is a programming language with C#-like, semicolon-based syntax compiled to C code. This guide covers the current syntax and usage.
+
+## Syntax
 
 Variable Declaration: int <identifier>; or int <identifier> = <value>;
 Assignment: <identifier> = <expression>;
@@ -12,7 +14,7 @@ Console Output: Console.WriteLine(<expression>);
 Conditional: if (<expression>) <statement> [else <statement>]
 Loop: while (<expression>) <statement>
 
-Example Program
+## Example Program
 int x = 5;
 int y = 10;
 x = y + 5;          // x = 15
@@ -24,7 +26,7 @@ Console.WriteLine("hi"); // Outputs "hi"
 if (x) Console.WriteLine(y);
 while (x) Console.WriteLine(y);
 
-Compilation
+## Compilation
 
 Write a `.dr` file (e.g., `example.dr`).
 Compile and run:
@@ -33,8 +35,9 @@ zig build run -- example.dr
 ```
 The compiler uses the `CC` environment variable for the back-end C compilation step. If `CC` is not set, `gcc` is used by default.
 
-Notes
+## Notes
 
 Semicolons (;) are required to terminate statements.
 Run in CLion or via a batch file for Windows compatibility.
+
 

--- a/docs/v1/variables.md
+++ b/docs/v1/variables.md
@@ -1,23 +1,25 @@
-Variables in Dream
-Overview
-The Dream language supports variable declarations and assignments with a C#-like syntax, using the int type for integers.
-Syntax
+# Variables in Dream
 
-Declaration: int <identifier>;
-Declares a variable with an initial value of 0.
+## Overview
+The Dream language supports variable declarations and assignments with a C#-like syntax using the `int` type for integers.
 
+## Syntax
 
-Assignment: <identifier> = <expression>;
-Assigns a value (number or expression) to a variable.
+**Declaration**: `int <identifier>;`
+: Declares a variable with an initial value of `0`.
 
+**Assignment**: `<identifier> = <expression>;`
+: Assigns a value (number or expression) to a variable.
 
+## Examples
 
-Examples
+```dream
 int x;        // Declares x, initialized to 0
 x = 42;       // Assigns 42 to x
 int y = 10;   // Declares and assigns 10 to y
+```
 
-Notes
+## Notes
 
 Variables are stored as local `long` values in the generated C code.
-Only int type is supported currently.
+Only the `int` type is supported currently.


### PR DESCRIPTION
## Description
- add an introduction page for the docs
- update index page links and sidebar to include new docs
- unify documentation headers

## Related Files
- `docs/index.html`
- `docs/index.md`
- `docs/v1/*.md`

## Changes
- new intro document
- sidebar now lists Introduction and Parentheses
- added Source Architecture link
- default page now loads intro
- standardized markdown headers across docs

## Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_6875c8314a50832bb0582298732333ef