### PR TITLE
Add logical NOT operator

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -126,3 +126,8 @@ Version 1.0.22 (2025-07-15)
 * Added logical AND (&&) and OR (||) operators.
 * Updated documentation and added a new test case.
 
+Version 1.0.23 (2025-07-15)
+
+* Added logical NOT (!) operator for expressions.
+* Updated documentation and added a new test case.
+

--- a/docs/v1/logical.md
+++ b/docs/v1/logical.md
@@ -1,10 +1,11 @@
 # Logical Operators in Dream
 
-Dream now supports logical conjunction and disjunction using the `&&` and `||` operators.
+Dream now supports logical conjunction and disjunction using the `&&` and `||` operators. Logical negation with the `!` operator is also available.
 
 ## Syntax
 
 ```
+!<expression>
 <expression> && <expression>
 <expression> || <expression>
 ```
@@ -18,4 +19,5 @@ int a = 1;
 int b = 0;
 if (a && b) Console.WriteLine(a);
 if (a || b) Console.WriteLine(a); // prints 1
+if (!b) Console.WriteLine(a);     // prints 1
 ```

--- a/docs/v1/usage.md
+++ b/docs/v1/usage.md
@@ -9,7 +9,7 @@ Variable Declaration: int <identifier>; or int <identifier> = <value>;
 Assignment: <identifier> = <expression>;
 Arithmetic: <identifier> = <expression> + <expression> or <expression> - <expression> or <expression> * <expression> or <expression> / <expression> or <expression> % <expression>;
 Comparison: <expression> < <expression> or <expression> > <expression> or <expression> <= <expression> or <expression> >= <expression> or <expression> == <expression> or <expression> != <expression>;
-Logical: <expression> && <expression> or <expression> || <expression>;
+Logical: !<expression> or <expression> && <expression> or <expression> || <expression>;
 Console Output: Console.WriteLine(<expression>);
     <expression> may be a variable, number, or quoted string.
 Conditional: if (<expression>) <statement> [else <statement>]

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -150,8 +150,8 @@ Token next_token(Lexer *lexer) {
       token.value = strdup("!=");
       lexer->pos += 2;
     } else {
-      token.type = TOKEN_UNKNOWN;
-      token.value = strndup(lexer->source + lexer->pos, 1);
+      token.type = TOKEN_NOT;
+      token.value = strdup("!");
       lexer->pos++;
     }
     break;

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -19,6 +19,7 @@ typedef enum {
   TOKEN_GE,
   TOKEN_EQEQ,
   TOKEN_NEQ,
+  TOKEN_NOT,
   TOKEN_AND,
   TOKEN_OR,
   TOKEN_SEMICOLON,

--- a/src/parser/expression.c
+++ b/src/parser/expression.c
@@ -5,8 +5,12 @@
 
 Node *parse_expression(Lexer *lexer, Token *token) {
   int unary_minus = 0;
-  if (token->type == TOKEN_MINUS) {
-    unary_minus = 1;
+  int unary_not = 0;
+  if (token->type == TOKEN_MINUS || token->type == TOKEN_NOT) {
+    if (token->type == TOKEN_MINUS)
+      unary_minus = 1;
+    else
+      unary_not = 1;
     free(token->value);
     *token = next_token(lexer);
   }
@@ -37,6 +41,8 @@ Node *parse_expression(Lexer *lexer, Token *token) {
   }
   if (unary_minus)
     left = create_node(NODE_UNARY_OP, "-", left, NULL, NULL);
+  if (unary_not)
+    left = create_node(NODE_UNARY_OP, "!", left, NULL, NULL);
   if ((token->type == TOKEN_PLUS || token->type == TOKEN_MINUS ||
        token->type == TOKEN_STAR || token->type == TOKEN_SLASH ||
        token->type == TOKEN_PERCENT || token->type == TOKEN_LT ||

--- a/tests/intermediate/logical_not.dr
+++ b/tests/intermediate/logical_not.dr
@@ -1,0 +1,3 @@
+int a = 1;
+if (!a) Console.WriteLine(a); // Expected: (no output)
+if (!0) Console.WriteLine(a); // Expected: 1


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added support for the logical NOT (`!`) operator. The lexer now recognizes `!` as its own token, the parser handles unary negation, and code generation outputs the correct C expression. Documentation has been updated to cover the new operator and a new regression test was added.

Related Files
- `src/lexer/lexer.c`
- `src/lexer/lexer.h`
- `src/parser/expression.c`
- `docs/v1/logical.md`
- `docs/v1/usage.md`
- `docs/v1/changelog.md`
- `tests/intermediate/logical_not.dr`

Changes
Implemented TOKEN_NOT in the lexer and parsed unary logical negation. Updated logical documentation to mention `!` and expanded usage guide. Added changelog entry for version 1.0.23 and created a new test file covering the feature.

Testing
```bash
zig build --verbose
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
No new dependencies were required.

Documentation
- Updated `docs/v1/logical.md`
- Updated `docs/v1/usage.md`
- Updated `docs/v1/changelog.md`

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None

------
https://chatgpt.com/codex/tasks/task_e_6875cbb458a0832bb41ca8fcc68f9921