### PR TITLE
Fix Gradle task dependency

### DIFF
--- a/idea/build.gradle.kts
+++ b/idea/build.gradle.kts
@@ -29,3 +29,7 @@ tasks.named<org.jetbrains.grammarkit.tasks.GenerateLexerTask>("generateLexer") {
 sourceSets["main"].java.srcDir("build/generated-src/flex")
 
 tasks.named<JavaCompile>("compileJava") { dependsOn("generateLexer") }
+
+tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileKotlin") {
+    dependsOn("generateLexer")
+}


### PR DESCRIPTION
Dream Compiler Pull Request

### Description
Added a missing dependency so that the Kotlin sources are compiled after the lexer is generated when building the IntelliJ plugin.

### Related Files
- `idea/build.gradle.kts`

### Changes
- `compileKotlin` task now depends on `generateLexer`.

### Testing
- `zig build`
- `./gradlew buildPlugin` *(failed: Network is unreachable)*

### Dependencies
- None

### Documentation
- None

### Checklist
- [x] `zig build` succeeds
- [ ] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

### Additional Notes
Build of the IntelliJ plugin did not complete due to network restrictions.

------
https://chatgpt.com/codex/tasks/task_e_6875e3b70c00832b8a2d9161bc7dbbb0