### PR TITLE
Update plugin to Java 21

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -152,3 +152,7 @@ Version 1.0.27 (2025-07-16)
 
 * Added `return` statements to exit the program early.
 * Updated documentation and added a regression test.
+
+Version 1.0.28 (2025-07-16)
+
+* Updated IntelliJ plugin build configuration to target Java 21.

--- a/idea/build.gradle.kts
+++ b/idea/build.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile> {
 }
 
 intellij {
-    version.set("2024.2")
+    version.set("2025.1")
     type.set("IC")
 }
 
@@ -32,8 +32,8 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("242")
-        untilBuild.set("242.*")
+        sinceBuild.set("251")
+        untilBuild.set("251.*")
     }
 
     withType<org.jetbrains.grammarkit.tasks.GenerateLexerTask> {


### PR DESCRIPTION
Dream Compiler Pull Request

## Description
Updated the IntelliJ IDEA plugin configuration to target Java 21. This prepares the plugin for the next IDE release that requires JDK 21.

## Related Files
Modified: `idea/build.gradle.kts`
Modified: `docs/v1/changelog.md`

## Changes
- Set IntelliJ platform version to `2025.1` and adjusted build numbers.
- Kept Java and Kotlin targets at 21 to match the new platform requirements.
- Documented this change in the changelog.

## Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

## Dependencies
None

## Documentation
Updated `docs/v1/changelog.md`.

## Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

## Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_6875f65484d0832ba9533fc03f9c986a