### PR TITLE
Add .dr support to syntax plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ The resulting VSIX and plugin zip live in their respective directories.
 
 ## Custom file icon
 
-Both editors show a Dream logo for `.mlg` files after installing the extensions.
+Both editors show a Dream logo for `.dr` files after installing the extensions.

--- a/idea/build.gradle.kts
+++ b/idea/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.0.0"
-    id("org.jetbrains.intellij") version "1.17.2"
+    id("org.jetbrains.intellij") version "1.17.3"
     id("org.jetbrains.grammarkit") version "2022.3.2"
 }
 
@@ -10,11 +10,11 @@ repositories {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = "17"
+    kotlinOptions.jvmTarget = "21"
 }
 
 tasks.withType<JavaCompile> {

--- a/idea/src/main/java/com/dream/DreamFileType.java
+++ b/idea/src/main/java/com/dream/DreamFileType.java
@@ -29,7 +29,7 @@ public class DreamFileType extends LanguageFileType {
     @NotNull
     @Override
     public String getDefaultExtension() {
-        return "mlg";
+        return "dr";
     }
 
     @Nullable

--- a/idea/src/main/resources/META-INF/plugin.xml
+++ b/idea/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
               implementationClass="com.dream.DreamFileType"
               fieldName="INSTANCE"
               language="Dream"
-              extensions="mlg"
+              extensions="dr"
               icon="/icons/Dream.svg"/>
     <lang.syntaxHighlighterFactory language="dream" implementationClass="com.dream.DreamSyntaxHighlighterFactory"/>
   </extensions>

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -20,7 +20,7 @@
           "dream"
         ],
         "extensions": [
-          ".mlg"
+        ".dr"
         ],
         "configuration": "./language-configuration.json",
         "icon": {


### PR DESCRIPTION
## Summary
- support `.dr` Dream files in VSCode and IntelliJ plugins
- use Java 21 toolchain and update IntelliJ plugin Gradle config
- update docs to mention `.dr` extension

## Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done`
- `gradle help --no-daemon --warning-mode all` in `idea/`


------
https://chatgpt.com/codex/tasks/task_e_6875f93cb5fc832b9065a3f1cc16f3bf