### PR TITLE
Fix VS Code syntax extension

### DIFF
--- a/vscode/out/extension.js
+++ b/vscode/out/extension.js
@@ -1,0 +1,3 @@
+function activate() {}
+function deactivate() {}
+module.exports = { activate, deactivate };


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Implemented a minimal `extension.js` so the VS Code package loads correctly, enabling syntax highlighting for `.dr` files.

Related Files
Added: `vscode/out/extension.js`

Changes
- Created stub activate/deactivate functions for the VS Code extension.
- Regenerated syntax data via `node scripts/genFromTokens.js`.

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
None

Documentation
No docs required.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None

------
https://chatgpt.com/codex/tasks/task_e_6875fc7bff80832b8d5a9b7f6fa9bfd4