### PR TITLE
Fix JetBrains plugin highlighting

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -156,3 +156,8 @@ Version 1.0.27 (2025-07-16)
 Version 1.0.28 (2025-07-16)
 
 * Updated IntelliJ plugin build configuration to target Java 21.
+
+Version 1.0.29 (2025-07-17)
+
+* Fixed JetBrains syntax highlighting by using the correct language id in plugin.xml.
+

--- a/idea/src/main/resources/META-INF/plugin.xml
+++ b/idea/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
     <fileType name="Dream File"
               implementationClass="com.dream.DreamFileType"
               fieldName="INSTANCE"
-              language="Dream"
+              language="dream"
               extensions="dr"
               icon="/icons/Dream.svg"/>
     <lang.syntaxHighlighterFactory language="dream" implementationClass="com.dream.DreamSyntaxHighlighterFactory"/>


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Fix JetBrains IDE syntax highlighting by correcting the `language` attribute in `plugin.xml` to match the `dream` language id. Documented the fix in `docs/v1/changelog.md`.

Related Files
- `idea/src/main/resources/META-INF/plugin.xml`
- `docs/v1/changelog.md`

Changes
- Updated JetBrains plugin fileType configuration with the proper language id.
- Added changelog entry for version 1.0.29.

Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_6875fe2e62ac832b9edcda3d0530a16f