### PR TITLE
Add block comment syntax highlighting

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -166,3 +166,8 @@ Version 1.0.30 (2025-07-17)
 
 * Added simple functions with the `func` keyword.
 * Updated documentation and added a new test case.
+
+Version 1.0.31 (2025-07-17)
+
+* Added block comment token for syntax highlighting.
+* Regenerated VS Code and JetBrains grammars.

--- a/idea/src/main/java/com/dream/DreamLexer.flex
+++ b/idea/src/main/java/com/dream/DreamLexer.flex
@@ -14,6 +14,7 @@ package com.dream;
   \\b\\d+\\b { return DreamTokenTypes.NUMBER; }
   \"([^\\\"\\n]|\\\\.)*\" { return DreamTokenTypes.STRING; }
   //.* { return DreamTokenTypes.COMMENT; }
+  "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/" { return DreamTokenTypes.COMMENTBLOCK; }
   [\t\r\n ]+ { return com.intellij.psi.TokenType.WHITE_SPACE; }
   . { return com.intellij.psi.TokenType.BAD_CHARACTER; }
 }

--- a/scripts/genFromTokens.js
+++ b/scripts/genFromTokens.js
@@ -17,7 +17,9 @@ function escapeFlex(re){
   return re.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 for(const t of tokens){
-  flex += `  ${escapeFlex(t.regex)} { return DreamTokenTypes.${t.name.toUpperCase()}; }\n`;
+  const escaped = escapeFlex(t.regex);
+  const pattern = t.regex.startsWith('\/\\*') ? `"${escaped}"` : escaped;
+  flex += `  ${pattern} { return DreamTokenTypes.${t.name.toUpperCase()}; }\n`;
 }
 flex += '  [\\t\\r\\n ]+ { return com.intellij.psi.TokenType.WHITE_SPACE; }\n  . { return com.intellij.psi.TokenType.BAD_CHARACTER; }\n}\n';
 fs.mkdirSync('idea/src/main/java/com/dream', { recursive: true });

--- a/tokens.json
+++ b/tokens.json
@@ -2,5 +2,6 @@
   {"name": "keyword", "regex": "\\b(if|else|while|for|do|break|continue|return|int|func)\\b", "scope": "keyword.control.dream"},
   {"name": "number", "regex": "\\b\\d+\\b", "scope": "constant.numeric.dream"},
   {"name": "string", "regex": "\"([^\\\"\\n]|\\\\.)*\"", "scope": "string.quoted.double.dream"},
-  {"name": "comment", "regex": "//.*", "scope": "comment.line.double-slash.dream"}
+  {"name": "comment", "regex": "//.*", "scope": "comment.line.double-slash.dream"},
+  {"name": "commentBlock", "regex": "\/\\*[^*]*\\*+([^/*][^*]*\\*+)*/", "scope": "comment.block.dream"}
 ]

--- a/vscode/syntaxes/dream.tmLanguage.json
+++ b/vscode/syntaxes/dream.tmLanguage.json
@@ -24,6 +24,10 @@
         {
           "name": "comment.line.double-slash.dream",
           "match": "//.*"
+        },
+        {
+          "name": "comment.block.dream",
+          "match": "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add `commentBlock` token for multiline comments
- update grammar and lexer generation to quote block comment regex
- regenerate VS Code and JetBrains syntax files
- document change in changelog

## Testing
- `gradle buildPlugin`
- `zig build`
- `for f in tests/**/*.dr; do zig build run -- "$f" > /dev/null || { echo FAIL; exit 1; }; done && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_687609995884832bbd72305321b0a816