### PR TITLE
Add color settings and code style support for JetBrains plugin

### DIFF
--- a/idea/src/main/java/com/dream/DreamCodeStyleSettings.java
+++ b/idea/src/main/java/com/dream/DreamCodeStyleSettings.java
@@ -1,0 +1,10 @@
+package com.dream;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+
+public class DreamCodeStyleSettings extends CustomCodeStyleSettings {
+    protected DreamCodeStyleSettings(CodeStyleSettings settings) {
+        super("DreamCodeStyleSettings", settings);
+    }
+}

--- a/idea/src/main/java/com/dream/DreamCodeStyleSettingsProvider.java
+++ b/idea/src/main/java/com/dream/DreamCodeStyleSettingsProvider.java
@@ -1,0 +1,39 @@
+package com.dream;
+
+import com.intellij.application.options.CodeStyleAbstractConfigurable;
+import com.intellij.application.options.CodeStyleAbstractPanel;
+import com.intellij.application.options.TabbedLanguageCodeStylePanel;
+import com.intellij.psi.codeStyle.CodeStyleConfigurable;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+import org.jetbrains.annotations.NotNull;
+
+public class DreamCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
+    @Override
+    public CustomCodeStyleSettings createCustomSettings(@NotNull CodeStyleSettings settings) {
+        return new DreamCodeStyleSettings(settings);
+    }
+
+    @Override
+    public String getConfigurableDisplayName() {
+        return "Dream";
+    }
+
+    @Override
+    public @NotNull CodeStyleConfigurable createConfigurable(@NotNull CodeStyleSettings settings,
+                                                             @NotNull CodeStyleSettings modelSettings) {
+        return new CodeStyleAbstractConfigurable(settings, modelSettings, getConfigurableDisplayName()) {
+            @Override
+            protected @NotNull CodeStyleAbstractPanel createPanel(@NotNull CodeStyleSettings settings) {
+                return new DreamCodeStyleMainPanel(getCurrentSettings(), settings);
+            }
+        };
+    }
+
+    private static class DreamCodeStyleMainPanel extends TabbedLanguageCodeStylePanel {
+        protected DreamCodeStyleMainPanel(CodeStyleSettings currentSettings, CodeStyleSettings settings) {
+            super(DreamLanguage.INSTANCE, currentSettings, settings);
+        }
+    }
+}

--- a/idea/src/main/java/com/dream/DreamColorSettingsPage.java
+++ b/idea/src/main/java/com/dream/DreamColorSettingsPage.java
@@ -1,0 +1,59 @@
+package com.dream;
+
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.openapi.options.colors.AttributesDescriptor;
+import com.intellij.openapi.options.colors.ColorDescriptor;
+import com.intellij.openapi.options.colors.ColorSettingsPage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Map;
+
+public class DreamColorSettingsPage implements ColorSettingsPage {
+    private static final AttributesDescriptor[] DESCRIPTORS = new AttributesDescriptor[]{
+            new AttributesDescriptor("Keyword", DreamSyntaxHighlighter.KEYWORD),
+            new AttributesDescriptor("Number", DreamSyntaxHighlighter.NUMBER),
+            new AttributesDescriptor("String", DreamSyntaxHighlighter.STRING),
+            new AttributesDescriptor("Comment", DreamSyntaxHighlighter.COMMENT)
+    };
+
+    @Override
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Override
+    public SyntaxHighlighter getHighlighter() {
+        return new DreamSyntaxHighlighter();
+    }
+
+    @NotNull
+    @Override
+    public String getDemoText() {
+        return "int x = 5;\nif (x > 0) {\n    Console.WriteLine(x);\n}";
+    }
+
+    @Nullable
+    @Override
+    public Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap() {
+        return null;
+    }
+
+    @Override
+    public AttributesDescriptor[] getAttributeDescriptors() {
+        return DESCRIPTORS;
+    }
+
+    @Override
+    public ColorDescriptor[] getColorDescriptors() {
+        return ColorDescriptor.EMPTY_ARRAY;
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Dream";
+    }
+}

--- a/idea/src/main/java/com/dream/DreamSyntaxHighlighter.java
+++ b/idea/src/main/java/com/dream/DreamSyntaxHighlighter.java
@@ -19,10 +19,10 @@ public class DreamSyntaxHighlighter extends SyntaxHighlighterBase {
         return lexer;
     }
 
-    private static final TextAttributesKey KEYWORD = TextAttributesKey.createTextAttributesKey("DREAM_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
-    private static final TextAttributesKey NUMBER = TextAttributesKey.createTextAttributesKey("DREAM_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
-    private static final TextAttributesKey STRING = TextAttributesKey.createTextAttributesKey("DREAM_STRING", DefaultLanguageHighlighterColors.STRING);
-    private static final TextAttributesKey COMMENT = TextAttributesKey.createTextAttributesKey("DREAM_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
+    public static final TextAttributesKey KEYWORD = TextAttributesKey.createTextAttributesKey("DREAM_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
+    public static final TextAttributesKey NUMBER = TextAttributesKey.createTextAttributesKey("DREAM_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
+    public static final TextAttributesKey STRING = TextAttributesKey.createTextAttributesKey("DREAM_STRING", DefaultLanguageHighlighterColors.STRING);
+    public static final TextAttributesKey COMMENT = TextAttributesKey.createTextAttributesKey("DREAM_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
 
     @NotNull
     @Override

--- a/idea/src/main/resources/META-INF/plugin.xml
+++ b/idea/src/main/resources/META-INF/plugin.xml
@@ -14,5 +14,7 @@
               extensions="dr"
               icon="/icons/Dream.svg"/>
     <lang.syntaxHighlighterFactory language="dream" implementationClass="com.dream.DreamSyntaxHighlighterFactory"/>
+    <colorSettingsPage implementation="com.dream.DreamColorSettingsPage"/>
+    <codeStyleSettingsProvider implementation="com.dream.DreamCodeStyleSettingsProvider"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added a color settings page and code style settings provider to the JetBrains IDE plugin so Dream syntax can be configured in the theme and code style editors.

Related Files
Added: `idea/src/main/java/com/dream/DreamColorSettingsPage.java`
Added: `idea/src/main/java/com/dream/DreamCodeStyleSettings.java`
Added: `idea/src/main/java/com/dream/DreamCodeStyleSettingsProvider.java`
Modified: `idea/src/main/java/com/dream/DreamSyntaxHighlighter.java`
Modified: `idea/src/main/resources/META-INF/plugin.xml`

Changes
- Exposed syntax highlighter TextAttribute keys so they can be referenced externally.
- Implemented a `ColorSettingsPage` for theme customization.
- Implemented minimal code style settings provider and custom settings.
- Registered the new components in `plugin.xml`.

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
None

Documentation
None

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
N/A

------
https://chatgpt.com/codex/tasks/task_e_6876114b2628832baf87dd24013d6240