### PR TITLE
Add block comment support to Dream compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The compiler currently supports:
 - `break` and `continue` statements
 - `return` statements
 - Braced blocks supporting multiple statements
+- Line (`//`) and block (`/* */`) comments
 
 More features such as functions are planned for future versions. See the [changelog](docs/v1/changelog.md) for details.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Use the version dropdown in the sidebar to view documentation for other releases
 - [Comparison](v1/comparison.md)
 - [Logical Operators](v1/logical.md)
 - [Console Output](v1/console.md)
+- [Comments](v1/comments.md)
 - [Functions](v1/functions.md)
 
 ### Control Flow

--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -171,3 +171,8 @@ Version 1.0.31 (2025-07-17)
 
 * Added block comment token for syntax highlighting.
 * Regenerated VS Code and JetBrains grammars.
+
+Version 1.0.32 (2025-07-18)
+
+* Lexer now supports C-style block comments.
+* Documented comments and added a regression test.

--- a/docs/v1/comments.md
+++ b/docs/v1/comments.md
@@ -1,0 +1,18 @@
+# Comments in Dream
+
+Dream supports two forms of comments that are ignored by the compiler.
+
+## Single-line comments
+Start with `//` and extend to the end of the line.
+
+## Block comments
+Begin with `/*` and end with `*/`. They may span multiple lines but cannot be nested.
+
+## Example
+```dream
+int x = 5; // single line
+
+/* multi-line
+   comment example */
+Console.WriteLine(x);
+```

--- a/docs/v1/usage.md
+++ b/docs/v1/usage.md
@@ -15,6 +15,7 @@ Console Output: Console.WriteLine(<expression>);
 Conditional: if (<expression>) <statement> [else <statement>]
 Loop: while (<expression>) <statement> or do <statement> while (<expression>) or for (<init>; <condition>; <increment>) <statement>;
 Return: return [<expression>];
+Comments: // single line or /* block */
 
 ## Example Program
 int x = 5;

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -28,6 +28,18 @@ Token next_token(Lexer *lexer) {
     return next_token(lexer);
   }
 
+  if (lexer->source[lexer->pos] == '/' &&
+      lexer->source[lexer->pos + 1] == '*') {
+    lexer->pos += 2;
+    while (lexer->source[lexer->pos] &&
+           !(lexer->source[lexer->pos] == '*' &&
+             lexer->source[lexer->pos + 1] == '/'))
+      lexer->pos++;
+    if (lexer->source[lexer->pos])
+      lexer->pos += 2;
+    return next_token(lexer);
+  }
+
   Token token = {TOKEN_UNKNOWN, NULL};
   if (lexer->source[lexer->pos] == '\0') {
     token.type = TOKEN_EOF;

--- a/tests/basic/block_comment.dr
+++ b/tests/basic/block_comment.dr
@@ -1,0 +1,4 @@
+int x = 5;
+/* this is a
+   block comment */
+Console.WriteLine(x); // Expected: 5


### PR DESCRIPTION
## Summary
- support `/* */` block comments in the lexer
- document comment syntax
- mention comments in usage guide and README
- update index and changelog
- add regression test for block comments

## Testing
- `zig build --summary all`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_687612c00fb8832bac3f574f39083452