### PR TITLE
Fix syntax highlighting scopes

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -176,3 +176,8 @@ Version 1.0.32 (2025-07-18)
 
 * Lexer now supports C-style block comments.
 * Documented comments and added a regression test.
+
+Version 1.0.33 (2025-07-18)
+
+* Standardized syntax token scopes so default editor themes highlight Dream files.
+* Regenerated VS Code grammar from updated token list.

--- a/tokens.json
+++ b/tokens.json
@@ -1,7 +1,7 @@
 [
-  {"name": "keyword", "regex": "\\b(if|else|while|for|do|break|continue|return|int|func)\\b", "scope": "keyword.control.dream"},
-  {"name": "number", "regex": "\\b\\d+\\b", "scope": "constant.numeric.dream"},
-  {"name": "string", "regex": "\"([^\\\"\\n]|\\\\.)*\"", "scope": "string.quoted.double.dream"},
-  {"name": "comment", "regex": "//.*", "scope": "comment.line.double-slash.dream"},
-  {"name": "commentBlock", "regex": "\/\\*[^*]*\\*+([^/*][^*]*\\*+)*/", "scope": "comment.block.dream"}
+  {"name": "keyword", "regex": "\\b(if|else|while|for|do|break|continue|return|int|func)\\b", "scope": "keyword.control"},
+  {"name": "number", "regex": "\\b\\d+\\b", "scope": "constant.numeric"},
+  {"name": "string", "regex": "\"([^\\\"\\n]|\\\\.)*\"", "scope": "string.quoted.double"},
+  {"name": "comment", "regex": "//.*", "scope": "comment.line.double-slash"},
+  {"name": "commentBlock", "regex": "\/\\*[^*]*\\*+([^/*][^*]*\\*+)*/", "scope": "comment.block"}
 ]

--- a/vscode/syntaxes/dream.tmLanguage.json
+++ b/vscode/syntaxes/dream.tmLanguage.json
@@ -10,23 +10,23 @@
     "tokens": {
       "patterns": [
         {
-          "name": "keyword.control.dream",
+          "name": "keyword.control",
           "match": "\\b(if|else|while|for|do|break|continue|return|int|func)\\b"
         },
         {
-          "name": "constant.numeric.dream",
+          "name": "constant.numeric",
           "match": "\\b\\d+\\b"
         },
         {
-          "name": "string.quoted.double.dream",
+          "name": "string.quoted.double",
           "match": "\"([^\\\"\\n]|\\\\.)*\""
         },
         {
-          "name": "comment.line.double-slash.dream",
+          "name": "comment.line.double-slash",
           "match": "//.*"
         },
         {
-          "name": "comment.block.dream",
+          "name": "comment.block",
           "match": "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/"
         }
       ]


### PR DESCRIPTION
Dream Compiler Pull Request

### Description
Updated syntax highlighting scopes so default editor themes correctly color Dream files.

### Related Files
Modified: `tokens.json`
Modified: `vscode/syntaxes/dream.tmLanguage.json`
Modified: `docs/v1/changelog.md`

### Changes
- standardized token scopes to common names
- regenerated VS Code grammar from updated tokens
- documented the update in the changelog

### Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

### Dependencies
No changes.

### Documentation
- `docs/v1/changelog.md`

### Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

### Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_687617413f30832ba229d3824ba1400f