### PR TITLE
Update highlight tokens for built-in keywords

### DIFF
--- a/idea/src/main/java/com/dream/DreamLexer.flex
+++ b/idea/src/main/java/com/dream/DreamLexer.flex
@@ -10,7 +10,7 @@ package com.dream;
 
 %%
 <YYINITIAL> {
-  \\b(if|else|while|for|do|break|continue|return|int|func)\\b { return DreamTokenTypes.KEYWORD; }
+  \\b(if|else|while|for|do|break|continue|return|int|func|Console|WriteLine)\\b { return DreamTokenTypes.KEYWORD; }
   \\b\\d+\\b { return DreamTokenTypes.NUMBER; }
   \"([^\\\"\\n]|\\\\.)*\" { return DreamTokenTypes.STRING; }
   //.* { return DreamTokenTypes.COMMENT; }

--- a/tokens.json
+++ b/tokens.json
@@ -1,5 +1,5 @@
 [
-  {"name": "keyword", "regex": "\\b(if|else|while|for|do|break|continue|return|int|func)\\b", "scope": "keyword.control"},
+  {"name": "keyword", "regex": "\\b(if|else|while|for|do|break|continue|return|int|func|Console|WriteLine)\\b", "scope": "keyword.control"},
   {"name": "number", "regex": "\\b\\d+\\b", "scope": "constant.numeric"},
   {"name": "string", "regex": "\"([^\\\"\\n]|\\\\.)*\"", "scope": "string.quoted.double"},
   {"name": "comment", "regex": "//.*", "scope": "comment.line.double-slash"},

--- a/vscode/syntaxes/dream.tmLanguage.json
+++ b/vscode/syntaxes/dream.tmLanguage.json
@@ -11,7 +11,7 @@
       "patterns": [
         {
           "name": "keyword.control",
-          "match": "\\b(if|else|while|for|do|break|continue|return|int|func)\\b"
+          "match": "\\b(if|else|while|for|do|break|continue|return|int|func|Console|WriteLine)\\b"
         },
         {
           "name": "constant.numeric",


### PR DESCRIPTION
## Summary
- add `Console` and `WriteLine` to the keyword regex in `tokens.json`
- regenerate VS Code grammar and JetBrains lexer

## Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f" > /tmp/test.log && tail -n 1 /tmp/test.log; done`

------
https://chatgpt.com/codex/tasks/task_e_687619bce868832bab651aa379814937