### PR TITLE
Fix JetBrains token sync

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -181,3 +181,8 @@ Version 1.0.33 (2025-07-18)
 
 * Standardized syntax token scopes so default editor themes highlight Dream files.
 * Regenerated VS Code grammar from updated token list.
+
+Version 1.0.34 (2025-07-18)
+
+* Synchronized JetBrains token definitions with `tokens.json`.
+* Updated generator to copy tokens into the plugin resources.

--- a/idea/src/main/resources/tokens.json
+++ b/idea/src/main/resources/tokens.json
@@ -1,7 +1,27 @@
 [
-  {"name": "keyword", "regex": "\\b(if|else|while|return|int)\\b", "scope": "keyword.control.dream"},
-  {"name": "number", "regex": "\\b\\d+\\b", "scope": "constant.numeric.dream"},
-  {"name": "string", "regex": "\"(?:\\\\.|[^\"])*\"", "scope": "string.quoted.double.dream"},
-  {"name": "comment", "regex": "//.*", "scope": "comment.line.double-slash.dream"},
-  {"name": "commentBlock", "regex": "/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/", "scope": "comment.block.dream"}
+  {
+    "name": "keyword",
+    "regex": "\\b(if|else|while|for|do|break|continue|return|int|func|Console|WriteLine)\\b",
+    "scope": "keyword.control"
+  },
+  {
+    "name": "number",
+    "regex": "\\b\\d+\\b",
+    "scope": "constant.numeric"
+  },
+  {
+    "name": "string",
+    "regex": "\"([^\\\"\\n]|\\\\.)*\"",
+    "scope": "string.quoted.double"
+  },
+  {
+    "name": "comment",
+    "regex": "//.*",
+    "scope": "comment.line.double-slash"
+  },
+  {
+    "name": "commentBlock",
+    "regex": "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/",
+    "scope": "comment.block"
+  }
 ]

--- a/scripts/genFromTokens.js
+++ b/scripts/genFromTokens.js
@@ -24,3 +24,7 @@ for(const t of tokens){
 flex += '  [\\t\\r\\n ]+ { return com.intellij.psi.TokenType.WHITE_SPACE; }\n  . { return com.intellij.psi.TokenType.BAD_CHARACTER; }\n}\n';
 fs.mkdirSync('idea/src/main/java/com/dream', { recursive: true });
 fs.writeFileSync('idea/src/main/java/com/dream/DreamLexer.flex', flex);
+
+// Keep JetBrains tokens.json in sync
+fs.mkdirSync('idea/src/main/resources', { recursive: true });
+fs.writeFileSync('idea/src/main/resources/tokens.json', JSON.stringify(tokens, null, 2));


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Updated the JetBrains plugin token definitions to match the main `tokens.json` and modified the generator script to copy these tokens automatically. Updated the changelog to reflect the changes.

Related Files
Modified: `scripts/genFromTokens.js`
Modified: `idea/src/main/resources/tokens.json`
Modified: `docs/v1/changelog.md`

Changes
- JetBrains token list now includes all keywords
- Generator now writes `tokens.json` into plugin resources for consistency

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
- None

Documentation
Updated `docs/v1/changelog.md`.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_68761c419870832b9da71578597ce425