### PR TITLE
Fix printf warnings for numeric output

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -186,3 +186,7 @@ Version 1.0.34 (2025-07-18)
 
 * Synchronized JetBrains token definitions with `tokens.json`.
 * Updated generator to copy tokens into the plugin resources.
+
+Version 1.0.35 (2025-07-18)
+
+* Fixed printf warnings by casting numeric output to `long`.

--- a/docs/v1/console.md
+++ b/docs/v1/console.md
@@ -18,6 +18,7 @@ Console.WriteLine("hello");   // Outputs the string "hello"
 
 ## Notes
 
-`Console.WriteLine` prints integers using `printf` so the output appears in
-decimal form. Strings are emitted directly as C string literals.
+`Console.WriteLine` prints integers using `printf` with the `%ld` format. Values
+are cast to `long` in the generated C code to avoid warnings. Strings are
+emitted directly as C string literals.
 

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -52,11 +52,13 @@ void generate_c(Compiler *compiler, Node *node) {
   } else if (node->type == NODE_WRITELINE) {
     if (node->left && node->left->type == NODE_STRING) {
       fprintf(out, "    printf(\"%%s\\n\", ");
+      gen_c_expr(out, node->left);
+      fprintf(out, ");\n");
     } else {
-      fprintf(out, "    printf(\"%%ld\\n\", ");
+      fprintf(out, "    printf(\"%%ld\\n\", (long)");
+      gen_c_expr(out, node->left);
+      fprintf(out, ");\n");
     }
-    gen_c_expr(out, node->left);
-    fprintf(out, ");\n");
   } else if (node->type == NODE_IF) {
     fprintf(out, "    if (");
     gen_c_expr(out, node->left);


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Fixed compiler-generated C code so Console.WriteLine casts numeric values to `long` before passing them to `printf`. This eliminates format warnings when compiling the generated C program.

Related Files
Modified: `src/codegen/codegen.c`
Modified: `docs/v1/console.md`
Modified: `docs/v1/changelog.md`

Changes
- Updated code generator to output `(long)` cast for numeric arguments in `printf`
- Documented the behavior in `console.md`
- Logged the change in `changelog.md`

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f" >/dev/null; done
```

Dependencies
No dependency changes.

Documentation
Updated console output documentation and changelog.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_68761e0e1d34832babf12d6aa241e1a9