### PR TITLE
Add else-if support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ The compiler currently supports:
 - `for` loops
 - `break` and `continue` statements
 - `return` statements
+- Basic functions with the `func` keyword
+- `string` variables for text storage
 - Braced blocks supporting multiple statements
 - Line (`//`) and block (`/* */`) comments
-
-More features such as functions are planned for future versions. See the [changelog](docs/v1/changelog.md) for details.
+See the [changelog](docs/v1/changelog.md) for details on recent additions.
 
 ## Getting Started
 

--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -195,3 +195,8 @@ Version 1.0.36 (2025-07-15)
 
 * Added `string` variable support and a new test.
 * Updated tokens and regenerated editor grammars.
+
+Version 1.0.37 (2025-07-18)
+
+* Added support for `else if` chains.
+* Updated documentation and added a regression test.

--- a/docs/v1/if.md
+++ b/docs/v1/if.md
@@ -1,12 +1,13 @@
 # If Statements in Dream
 
-Dream supports conditional execution using the `if` keyword and an optional `else` clause.
+Dream supports conditional execution using the `if` keyword. `else` and `else if` clauses provide alternate branches.
 
 Syntax
 ------
 
 ```
 if (<expression>) <statement>
+else if (<expression>) <statement>
 else <statement>
 ```
 
@@ -26,4 +27,16 @@ if (x) {
 ```
 
 This prints `1` because `x` is nonzero.
+
+You can chain conditions using `else if`:
+
+```
+int y = 0;
+if (y == 1)
+    Console.WriteLine(1);
+else if (y == 0)
+    Console.WriteLine(2);
+else
+    Console.WriteLine(3);
+```
 

--- a/src/parser/statement.c
+++ b/src/parser/statement.c
@@ -226,12 +226,10 @@ Node *parse_statement(Lexer *lexer, Token *token) {
         *token = next_token(lexer);
       } else {
         else_body = parse_statement(lexer, token);
-        if (token->type != TOKEN_SEMICOLON) {
-          fprintf(stderr, "Expected semicolon\n");
-          exit(1);
+        if (token->type == TOKEN_SEMICOLON) {
+          free(token->value);
+          *token = next_token(lexer);
         }
-        free(token->value);
-        *token = next_token(lexer);
       }
     }
     return create_node(NODE_IF, NULL, cond, body, else_body);

--- a/tests/intermediate/else_if.dr
+++ b/tests/intermediate/else_if.dr
@@ -1,0 +1,8 @@
+int x = 0;
+if (x == 1) {
+    Console.WriteLine(1);
+} else if (x == 0) {
+    Console.WriteLine(2);
+} else {
+    Console.WriteLine(3);
+}


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added `else if` chain handling in the parser and introduced a new regression test. Documentation was updated to explain the feature and the README feature list now includes functions and string variables.

Related Files
Modified: `src/parser/statement.c`
Modified: `docs/v1/if.md`
Modified: `README.md`
Modified: `docs/v1/changelog.md`
Added: `tests/intermediate/else_if.dr`

Changes
* Parser now consumes semicolons in `else` branches only when present, enabling `else if` statements with or without braces.
* Documentation and changelog updated to cover the new syntax.
* README feature list now reflects functions and string variables.

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
No new dependencies.

Documentation
Updated `docs/v1/if.md` and `docs/v1/changelog.md`.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_6876258a5f4c832baa3dbf0595ca9239