### PR TITLE
Improve C code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,19 @@ but aims to grow into a fully featured compiler. This repository contains the so
 
 The compiler currently supports:
 
-- Integer variables and assignments
-- Arithmetic with `+`, `-`, `*` and `/`
+- Integer and string variables with assignments
+- Arithmetic with `+`, `-`, `*`, `/` and `%`
 - Comparison operators `<`, `>`, `<=`, `>=`, `==` and `!=`
 - Console output via `Console.WriteLine` (numbers and strings)
 - Simple `if` statements with optional `else`
-- `while` loops
-- `do-while` loops
-- `for` loops
+- `while`, `do-while` and `for` loops
 - `break` and `continue` statements
 - `return` statements
+- Functions with no parameters
 - Braced blocks supporting multiple statements
 - Line (`//`) and block (`/* */`) comments
 
-More features such as functions are planned for future versions. See the [changelog](docs/v1/changelog.md) for details.
+See the [changelog](docs/v1/changelog.md) for a detailed history of features.
 
 ## Getting Started
 


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Implemented a cleanup to the C code generator. Binary and unary
expressions no longer emit redundant parentheses, producing cleaner C
output. The README feature list now reflects current language support.

Related Files
Modified: `src/codegen/codegen.c`
Modified: `README.md`

Changes
- Added `gen_c_expr_internal` helper to control parentheses output.
- Updated `gen_c_expr` to call the helper and removed duplicate
  parentheses in generated C.
- Updated README feature list to include functions, string variables and
  modulo operator.

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
- None

Documentation
- Updated `README.md` feature list.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None

------
https://chatgpt.com/codex/tasks/task_e_6876258a5f4c832baa3dbf0595ca9239