### PR TITLE
Fix redundant parentheses in generated C

### DIFF
--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -11,6 +11,7 @@ typedef struct {
 } Compiler;
 
 void gen_c_expr(Compiler *compiler, FILE *out, Node *expr);
+void gen_c_expr_unwrapped(Compiler *compiler, FILE *out, Node *expr);
 void generate_c(Compiler *compiler, Node *node);
 void generate_c_function(Compiler *compiler, Node *node);
 


### PR DESCRIPTION
Dream Compiler Pull Request

**Description**
Resolved compiler warnings caused by extra parentheses around equality checks in generated C. The code generator now has an `gen_c_expr_unwrapped` helper used for conditional expressions so the produced code no longer emits patterns like `if ((i == 3))`.

**Related Files**
Modified: `src/codegen/codegen.c`
Modified: `src/codegen/codegen.h`

**Changes**
- Added `gen_c_expr_impl` with optional wrapping and new `gen_c_expr_unwrapped` function
- Updated `generate_c` to use the unwrapped variant for `if`, `while` and `do-while`

**Testing**
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```
Both commands ran without errors.

**Dependencies**
- None

**Documentation**
- No documentation changes required

**Checklist**
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

**Additional Notes**
None

------
https://chatgpt.com/codex/tasks/task_e_687631d8d59c832babd0c24641bdd9e8