### PR TITLE
Fix plugin COMMA token

### DIFF
--- a/idea/src/main/java/com/dream/DreamTokenTypes.java
+++ b/idea/src/main/java/com/dream/DreamTokenTypes.java
@@ -11,4 +11,5 @@ public interface DreamTokenTypes {
     IElementType STRING = new DreamElementType("STRING");
     IElementType COMMENT = new DreamElementType("COMMENT");
     IElementType COMMENTBLOCK = new DreamElementType("COMMENTBLOCK");
+    IElementType COMMA = new DreamElementType("COMMA");
 }


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added missing `COMMA` token definition in the JetBrains plugin. This fixes a build error when running `buildPlugin`.

Related Files
Modified: `idea/src/main/java/com/dream/DreamTokenTypes.java`

Changes
- Declared `COMMA` element type next to existing tokens so the generated lexer compiles.

Testing
```bash
zig build
shopt -s globstar
for f in tests/**/*.dr; do zig build run -- "$f"; done
```

Dependencies
- None

Documentation
- No docs needed for this fix.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
None.

------
https://chatgpt.com/codex/tasks/task_e_687633726530832bb8ebc0e280091794