### PR TITLE
Fix JetBrains code style settings page

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -225,3 +225,8 @@ Version 1.0.42 (2025-07-23)
 
 * `Console.WriteLine` now prints boolean variables as `true` or `false`.
 * Updated documentation to mention boolean output.
+
+Version 1.0.43 (2025-07-24)
+
+* Fixed JetBrains code style page hanging by registering a language code style provider.
+

--- a/idea/src/main/java/com/dream/DreamLanguageCodeStyleSettingsProvider.java
+++ b/idea/src/main/java/com/dream/DreamLanguageCodeStyleSettingsProvider.java
@@ -1,0 +1,27 @@
+package com.dream;
+
+import com.intellij.lang.Language;
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable;
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider;
+import org.jetbrains.annotations.NotNull;
+
+public class DreamLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSettingsProvider {
+    @NotNull
+    @Override
+    public Language getLanguage() {
+        return DreamLanguage.INSTANCE;
+    }
+
+    @Override
+    public void customizeSettings(@NotNull CodeStyleSettingsCustomizable consumer, @NotNull SettingsType settingsType) {
+        if (settingsType == SettingsType.INDENT_SETTINGS) {
+            consumer.showStandardOptions("INDENT_SIZE", "TAB_SIZE", "USE_TAB_CHARACTER");
+        }
+    }
+
+    @NotNull
+    @Override
+    public String getCodeSample(@NotNull SettingsType settingsType) {
+        return "int x = 5;\nif (x > 0) {\n    Console.WriteLine(x);\n}";
+    }
+}

--- a/idea/src/main/resources/META-INF/plugin.xml
+++ b/idea/src/main/resources/META-INF/plugin.xml
@@ -16,5 +16,6 @@
     <lang.syntaxHighlighterFactory language="dream" implementationClass="com.dream.DreamSyntaxHighlighterFactory"/>
     <colorSettingsPage implementation="com.dream.DreamColorSettingsPage"/>
     <codeStyleSettingsProvider implementation="com.dream.DreamCodeStyleSettingsProvider"/>
+    <langCodeStyleSettingsProvider implementation="com.dream.DreamLanguageCodeStyleSettingsProvider"/>
   </extensions>
 </idea-plugin>


### PR DESCRIPTION
Dream Compiler Pull Request

### Description
Implemented a `LanguageCodeStyleSettingsProvider` for the JetBrains plugin to stop the code style settings page from hanging.

### Related Files
- `idea/src/main/java/com/dream/DreamLanguageCodeStyleSettingsProvider.java`
- `idea/src/main/resources/META-INF/plugin.xml`
- `docs/v1/changelog.md`

### Changes
Added new provider class registered in `plugin.xml` to supply sample text and basic indent options.
Updated changelog.

### Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done && echo OK
```

### Dependencies
None

### Documentation
Updated `docs/v1/changelog.md` with version 1.0.43 entry.

### Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

### Additional Notes
None

------
https://chatgpt.com/codex/tasks/task_e_6876373b2854832baaf77eeb790cccd7