### PR TITLE
Automate token generation in JetBrains build

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Dream Compiler is released under the [MIT License](LICENSE).
 
 ## Syntax Highlighting
 
-Generate the VS Code grammar and JetBrains lexer from `tokens.json`:
+Generate the VS Code grammar from `tokens.json`:
 
 ```bash
 node scripts/genFromTokens.js
@@ -106,6 +106,7 @@ npx vsce package
 cd idea
 ./gradlew buildPlugin
 ```
+The build will automatically regenerate the lexer and token definitions from `tokens.json`.
 
 The resulting VSIX and plugin zip live in their respective directories.
 

--- a/idea/build.gradle.kts
+++ b/idea/build.gradle.kts
@@ -33,6 +33,11 @@ tasks {
         enabled = false
     }
 
+    val generateTokens by registering(Exec::class) {
+        workingDir = rootDir
+        commandLine("node", "scripts/genFromTokens.js")
+    }
+
     patchPluginXml {
         sinceBuild.set("251")
         untilBuild.set("251.*")
@@ -43,6 +48,7 @@ tasks {
         targetDir.set("build/generated-src/flex/com/dream")
         targetClass.set("DreamLexer")
         purgeOldFiles.set(true)
+        dependsOn(generateTokens)
     }
 }
 


### PR DESCRIPTION
## Summary
- run `scripts/genFromTokens.js` automatically during the JetBrains build
- document that JetBrains builds regenerate tokens automatically

## Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68763f0e5644832bb517ca58221d4603