### PR TITLE
Fix compiler initialization for bool vars

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -226,3 +226,7 @@ Version 1.0.42 (2025-07-23)
 
 * `Console.WriteLine` now prints boolean variables as `true` or `false`.
 * Updated documentation to mention boolean output.
+
+Version 1.0.43 (2025-07-24)
+
+* Fixed uninitialized boolean variable tracking in the driver.

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
   mkdir("build", 0755);
   mkdir("build/bin", 0755);
 #endif
-  Compiler compiler = {fopen("build/bin/dream.c", "w"), NULL, 0};
+  Compiler compiler = {fopen("build/bin/dream.c", "w"), NULL, 0, NULL, 0};
   if (!compiler.output) {
     fprintf(stderr, "Failed to open output file\n");
     return 1;


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Fixed an initialization bug in `src/driver/main.c` where the `Compiler` struct left boolean tracking fields uninitialized. Updated `docs/v1/changelog.md` with a new entry.

Related Files
Modified: `src/driver/main.c`
Modified: `docs/v1/changelog.md`

Changes
- Initialize `bool_vars` and `bool_var_count` to `NULL` and `0` when constructing the compiler.
- Documented the fix in the changelog.

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
None

Documentation
Updated `docs/v1/changelog.md` with version 1.0.43 entry.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
N/A

------
https://chatgpt.com/codex/tasks/task_e_6876485c0a14832b848493b17d16f01e