### PR TITLE
Add switch keywords to syntax tokens

### DIFF
--- a/idea/src/main/java/com/dream/DreamLexer.flex
+++ b/idea/src/main/java/com/dream/DreamLexer.flex
@@ -10,7 +10,7 @@ package com.dream;
 
 %%
 <YYINITIAL> {
-  \\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine)\\b { return DreamTokenTypes.KEYWORD; }
+  \\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine|switch|case|default)\\b { return DreamTokenTypes.KEYWORD; }
   \\b\\d+\\b { return DreamTokenTypes.NUMBER; }
   \"([^\\\"\\n]|\\\\.)*\" { return DreamTokenTypes.STRING; }
   //.* { return DreamTokenTypes.COMMENT; }

--- a/idea/src/main/resources/tokens.json
+++ b/idea/src/main/resources/tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "keyword",
-    "regex": "\\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine)\\b",
+    "regex": "\\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine|switch|case|default)\\b",
     "scope": "keyword.control"
   },
   {

--- a/idea/tokens.json
+++ b/idea/tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "keyword",
-    "regex": "\\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine)\\b",
+    "regex": "\\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine|switch|case|default)\\b",
     "scope": "keyword.control"
   },
   {

--- a/vscode/syntaxes/dream.tmLanguage.json
+++ b/vscode/syntaxes/dream.tmLanguage.json
@@ -11,7 +11,7 @@
       "patterns": [
         {
           "name": "keyword.control",
-          "match": "\\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine)\\b"
+          "match": "\\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine|switch|case|default)\\b"
         },
         {
           "name": "constant.numeric",


### PR DESCRIPTION
## Summary
- update syntax token regex with `switch`, `case`, and `default`
- regenerate VS Code grammar and JetBrains lexer from updated tokens

## Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f" || break; done`

------
https://chatgpt.com/codex/tasks/task_e_6876637821ec832b8f58af0b246f4fb7