### PR TITLE
Fix JFlex lexer syntax

### DIFF
--- a/idea/src/main/java/com/dream/DreamLexer.flex
+++ b/idea/src/main/java/com/dream/DreamLexer.flex
@@ -13,11 +13,11 @@ package com.dream;
   \\b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine|switch|case|default)\\b { return DreamTokenTypes.KEYWORD; }
   \\b\\d+\\b { return DreamTokenTypes.NUMBER; }
   \"([^\\\"\\n]|\\\\.)*\" { return DreamTokenTypes.STRING; }
-  /\\*\\*[^*]*\\*+(?:[^\/\*][^*]*\\*+)\*\/|///.* { return DreamTokenTypes.COMMENTDOC; }
-  //.* { return DreamTokenTypes.COMMENT; }
-  /\\*[^*]*\\*+([^\/\*][^*]*\\*+)\*\/ { return DreamTokenTypes.COMMENTBLOCK; }
+  "/*""**"([^*]|"*"+[^/*])*"*"+"/" | "///".* { return DreamTokenTypes.COMMENTDOC; }
+  "//".* { return DreamTokenTypes.COMMENT; }
+  "/*"[^*]*"*"+([^/*][^*]*"*"+)*"/" { return DreamTokenTypes.COMMENTBLOCK; }
   [a-zA-Z_][a-zA-Z0-9_]* { return DreamTokenTypes.IDENTIFIER; }
-  \\+\\+|--|\\+=|-=|\\*=|/=|%=|\\+|-|\\*|\\/|%|<=|>=|==|!=|<|>|&&|\\|\\||!|=|\\? { return DreamTokenTypes.OPERATOR; }
+  "++"|"--"|"+="|"-="|"*="|"/="|"%="|"+"|"-"|"*"|"/"|"%"|"<="|">="|"=="|"!="|"<"|">"|"&&"|"||"|"!"|"="|"?" { return DreamTokenTypes.OPERATOR; }
   ; { return DreamTokenTypes.SEMICOLON; }
   , { return DreamTokenTypes.COMMA; }
   \\. { return DreamTokenTypes.DOT; }


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Fixed malformed regular expressions in the JetBrains lexer specification. The lexer now builds with JFlex without syntax errors.

Related Files
Modified: `idea/src/main/java/com/dream/DreamLexer.flex`

Changes
- Rewrote comment and operator patterns to use valid JFlex syntax.
- Verified lexer generation with `jflex`.

Testing
```bash
zig build
for f in tests/*/*.dr; do zig build run -- "$f"; done
```

Dependencies
None

Documentation
No documentation changes required.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
N/A

------
https://chatgpt.com/codex/tasks/task_e_68767451af30832bbc54430e7cd7fe35