### PR TITLE
Fix comment regex in tokens

### DIFF
--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -256,3 +256,8 @@ Version 1.0.48 (2025-07-28)
 * Extended syntax highlighting tokens with identifiers, bracket punctuation and documentation comments.
 * Fixed block comment handling in the lexer generator.
 * Regenerated editor grammars.
+
+Version 1.0.49 (2025-07-29)
+
+* Fixed syntax highlighting regressions for keywords and block comments.
+* Regenerated editor grammars.

--- a/idea/src/main/java/com/dream/DreamLexer.flex
+++ b/idea/src/main/java/com/dream/DreamLexer.flex
@@ -13,9 +13,9 @@ package com.dream;
   \b(if|else|while|for|do|break|continue|return|int|string|bool|true|false|func|Console|WriteLine|switch|case|default)\b { return DreamTokenTypes.KEYWORD; }
   \b\d+\b { return DreamTokenTypes.NUMBER; }
   "([^\"\n]|\\.)*" { return DreamTokenTypes.STRING; }
-  "/\*\*[^*]*\*+([^\/\*][^*]*\*+)\*\/|\/\//.*" { return DreamTokenTypes.COMMENTDOC; }
+  "/\*\*[^]*?\\*\/|\/\//.*" { return DreamTokenTypes.COMMENTDOC; }
   \/\/.* { return DreamTokenTypes.COMMENT; }
-  "/\*[^*]*\*+([^\/\*][^*]*\*+)\*\/" { return DreamTokenTypes.COMMENTBLOCK; }
+  "/\*[\s\S]*?\\*\/" { return DreamTokenTypes.COMMENTBLOCK; }
   [a-zA-Z_][a-zA-Z0-9_]* { return DreamTokenTypes.IDENTIFIER; }
   "++"|"--"|"+="|"-="|"*="|"/="|"%="|"+"|"-"|"*"|"/"|"%"|"<="|">="|"=="|"!="|"<"|">"|"&&"|"||"|"!"|"="|"?" { return DreamTokenTypes.OPERATOR; }
   ; { return DreamTokenTypes.SEMICOLON; }

--- a/idea/src/main/resources/tokens.json
+++ b/idea/src/main/resources/tokens.json
@@ -16,7 +16,7 @@
   },
   {
     "name": "commentDoc",
-    "regex": "/\\*\\*[^*]*\\*+([^/*][^*]*\\*+)*/|///.*",
+    "regex": "/\\*\\*[^]*?\\*/|///.*",
     "scope": "comment.block.documentation"
   },
   {
@@ -26,7 +26,7 @@
   },
   {
     "name": "commentBlock",
-    "regex": "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/",
+    "regex": "/\\*[\\s\\S]*?\\*/",
     "scope": "comment.block"
   },
   {

--- a/tokens.json
+++ b/tokens.json
@@ -16,7 +16,7 @@
   },
   {
     "name": "commentDoc",
-    "regex": "\/\\*\\*[^*]*\\*+([^/*][^*]*\\*+)*/|///.*",
+    "regex": "\/\\*\\*[^]*?\\*\/|///.*",
     "scope": "comment.block.documentation"
   },
   {
@@ -26,7 +26,7 @@
   },
   {
     "name": "commentBlock",
-    "regex": "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/",
+    "regex": "\/\\*[\\s\\S]*?\\*\/",
     "scope": "comment.block"
   },
   {

--- a/vscode/syntaxes/dream.tmLanguage.json
+++ b/vscode/syntaxes/dream.tmLanguage.json
@@ -23,7 +23,7 @@
         },
         {
           "name": "comment.block.documentation",
-          "match": "/\\*\\*[^*]*\\*+([^/*][^*]*\\*+)*/|///.*"
+          "match": "/\\*\\*[^]*?\\*/|///.*"
         },
         {
           "name": "comment.line.double-slash",
@@ -31,7 +31,7 @@
         },
         {
           "name": "comment.block",
-          "match": "/\\*[^*]*\\*+([^/*][^*]*\\*+)*/"
+          "match": "/\\*[\\s\\S]*?\\*/"
         },
         {
           "name": "variable.other",


### PR DESCRIPTION
## Summary
- fix broken comment regex patterns
- regenerate syntax highlighting artifacts
- update changelog

## Testing
- `npx vsce package --no-dependencies`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68767ff4d668832b95ebf55dd342aadd