### PR TITLE
Docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dream Compiler
 
-Dream is a advanced compiler that transforms a C#-like language called Dream into C code. The project is experimental 
+Dream is an advanced compiler that transforms a C#-like language called Dream into C code. The project is experimental
 but aims to grow into a fully featured compiler. This repository contains the source, example code, tests and documentation.
 
 ## Features

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,13 +31,20 @@
                         <li><a href="#" data-md="parentheses.md">Parentheses</a></li>
                         <li><a href="#" data-md="comparison.md">Comparison</a></li>
                         <li><a href="#" data-md="logical.md">Logical Operators</a></li>
+                        <li><a href="#" data-md="conditional.md">Conditional Operator</a></li>
                         <li><a href="#" data-md="console.md">Console Output</a></li>
+                        <li><a href="#" data-md="strings.md">String Literals</a></li>
+                        <li><a href="#" data-md="comments.md">Comments</a></li>
+                        <li><a href="#" data-md="functions.md">Functions</a></li>
+                        <li><a href="#" data-md="classes.md">Classes</a></li>
                     </ul>
                 </li>
                 <li class="category"><span>Control Flow</span>
                     <ul>
                         <li><a href="#" data-md="if.md">If Statements</a></li>
-                        <li><a href="#" data-md="loops.md">While Loops</a></li>
+                        <li><a href="#" data-md="loops.md">Loops</a></li>
+                        <li><a href="#" data-md="switch.md">Switch Statements</a></li>
+                        <li><a href="#" data-md="return.md">Return</a></li>
                     </ul>
                 </li>
                 <li><a href="#" data-md="changelog.md">Changelog</a></li>

--- a/docs/v1/usage.md
+++ b/docs/v1/usage.md
@@ -51,6 +51,6 @@ The compiler uses the `CC` environment variable for the back-end C compilation s
 ## Notes
 
 Semicolons (;) are required to terminate statements.
-Run in CLion or via a batch file for Windows compatibility.
+Run the compiler in CLion or via a batch script on Windows for compatibility.
 
 


### PR DESCRIPTION
Dream Compiler Pull Request

## Description
- refreshed README wording
- expanded sidebar in `docs/index.html`
- clarified a note in the usage guide

## Related Files
- `README.md`
- `docs/index.html`
- `docs/v1/usage.md`

## Changes
- grammar fix in README opening paragraph
- sidebar now lists every doc page and uses `Loops` instead of `While Loops`
- clarified Windows instructions in usage guide

## Testing
- `zig build`
- ran each test with `zig build run -- <test>`

## Dependencies
- none

## Documentation
- updated `README.md`
- updated `docs/index.html`
- updated `docs/v1/usage.md`

## Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

## Additional Notes
- n/a

------
https://chatgpt.com/codex/tasks/task_e_6876bcc8d0bc832b98cf9b83f751eedd