### PR TITLE
Update grammar docs for arrays

### DIFF
--- a/docs/grammer/grammer.md
+++ b/docs/grammer/grammer.md
@@ -114,7 +114,7 @@ If the **Type** is omitted the function returns `void`. (Internally represented 
 ```ebnf
 GlobalVariableDeclaration ::= VariableDeclaration                                     // Implemented
 VariableDeclaration      ::= Type VariableDeclarator { "," VariableDeclarator } ";"   // Implemented
-VariableDeclarator       ::= Identifier [ "[" Number "]" ] [ "=" Expression ]         // Partial (arrays pending)
+VariableDeclarator       ::= Identifier [ "[" Number "]" ] [ "=" Expression ]         // Implemented – supports arrays of primitive types
 ```
 
 ### 2.4 Statements
@@ -216,7 +216,7 @@ ConsoleCall         ::= "Console" "." ("WriteLine" | "Write") Invocation        
 
 ## 4 Future work (non‑normative)
 
-* Arrays, structs and generics.
+* Generics.
 * Access modifiers (`public`, `private`, …).
 * Exception handling (`try`‑`catch`).
 * Attributes and annotations.

--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -360,3 +360,8 @@ Version 1.0.66 (2025-08-13)
 * Added fixed-size arrays for `bool`, `char` and `string` types.
 * Updated array documentation and grammar notes.
 * Added new regression tests for the additional array types.
+
+Version 1.0.67 (2025-08-14)
+
+* Updated grammar specification to reflect implemented array support.
+* Removed arrays from the future work list.


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Updated grammar specification to note array support and removed outdated future work item. Added changelog entry for version 1.0.67.

Related Files
- `docs/grammer/grammer.md`
- `docs/v1/changelog.md`

Changes
- Document arrays as implemented in `grammer.md`
- Trim future work bullet to remove arrays
- Record update in `changelog.md`

Testing
```bash
zig build
for f in $(find tests -name '*.dr'); do zig build run -- "$f" >/tmp/t.log 2>&1 || { echo FAILED $f; cat /tmp/t.log; exit 1; }; done
```

Dependencies
None

Documentation
Updated grammar and changelog.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes


------
https://chatgpt.com/codex/tasks/task_e_6877f803aed8832babde858ad6e1771d