### PR TITLE
Add typed function returns

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -18,7 +18,7 @@
 - `while`, `do-while`, and `for` loops
 - `break` and `continue` statements
 - `return` statements
-- Functions with parameters and return values
+ - Functions with parameters and typed return values
 - Classes and structs with field access and object instantiation
 - Console output via `Console.Write` and `Console.WriteLine`
 - String literals with escape sequences and concatenation using `+`

--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -365,3 +365,9 @@ Version 1.0.67 (2025-08-14)
 
 * Updated grammar specification to reflect implemented array support.
 * Removed arrays from the future work list.
+
+Version 1.0.68 (2025-08-16)
+
+* Functions can now declare an explicit return type after `func`.
+* Updated code generation to handle typed returns.
+* Added documentation and a regression test for typed return values.

--- a/docs/v1/functions.md
+++ b/docs/v1/functions.md
@@ -1,11 +1,11 @@
 # Functions in Dream
 
-Dream allows defining reusable blocks of code using the `func` keyword. Functions now support parameters and return an integer value using the `return` statement.
+Dream allows defining reusable blocks of code using the `func` keyword. A function may specify a return type immediately after `func`. If omitted the function returns nothing (`void`).
 
 ## Syntax
 
 ```
-func <name>(<type> <param>[, <type> <param>]*) {
+func [returnType] <name>(<type> <param>[, <type> <param>]*) {
     <statements>
 }
 ```
@@ -19,9 +19,15 @@ Call a function using its name followed by `()` and optionally arguments.
 ## Example
 
 ```dream
-func Add(int a, int b) {
+func int Add(int a, int b) {
     return a + b;
 }
 
 Console.WriteLine(Add(2, 3));
+
+func string Hello() {
+    return "hi";
+}
+
+Console.WriteLine(Hello());
 ```

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -14,6 +14,14 @@ typedef struct {
   int float_var_count;
   char **char_vars;
   int char_var_count;
+  char **string_funcs;
+  int string_func_count;
+  char **bool_funcs;
+  int bool_func_count;
+  char **float_funcs;
+  int float_func_count;
+  char **char_funcs;
+  int char_func_count;
 } Compiler;
 
 void gen_c_expr(Compiler *compiler, FILE *out, Node *expr);

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -39,7 +39,8 @@ int main(int argc, char *argv[]) {
   mkdir("build", 0755);
   mkdir("build/bin", 0755);
 #endif
-  Compiler compiler = {fopen("build/bin/dream.c", "w"), NULL, 0, NULL, 0, NULL, 0, NULL, 0};
+  Compiler compiler = {fopen("build/bin/dream.c", "w"), NULL, 0, NULL, 0, NULL, 0, NULL, 0,
+                        NULL, 0, NULL, 0, NULL, 0, NULL, 0};
   if (!compiler.output) {
     fprintf(stderr, "Failed to open output file\n");
     return 1;
@@ -102,6 +103,18 @@ int main(int argc, char *argv[]) {
   for (int i = 0; i < compiler.char_var_count; i++)
     free(compiler.char_vars[i]);
   free(compiler.char_vars);
+  for (int i = 0; i < compiler.string_func_count; i++)
+    free(compiler.string_funcs[i]);
+  free(compiler.string_funcs);
+  for (int i = 0; i < compiler.bool_func_count; i++)
+    free(compiler.bool_funcs[i]);
+  free(compiler.bool_funcs);
+  for (int i = 0; i < compiler.float_func_count; i++)
+    free(compiler.float_funcs[i]);
+  free(compiler.float_funcs);
+  for (int i = 0; i < compiler.char_func_count; i++)
+    free(compiler.char_funcs[i]);
+  free(compiler.char_funcs);
   fclose(compiler.output);
   free(source);
   free(token.value);

--- a/src/parser/declaration.c
+++ b/src/parser/declaration.c
@@ -125,6 +125,13 @@ Node *parse_declaration(Lexer *lexer, Token *token) {
   } else if (token->type == TOKEN_FUNC) {
     free(token->value);
     *token = next_token(lexer);
+    Node *ret_type = NULL;
+    if (token->type == TOKEN_INT || token->type == TOKEN_STRING_TYPE ||
+        token->type == TOKEN_BOOL_TYPE || token->type == TOKEN_FLOAT_TYPE ||
+        token->type == TOKEN_CHAR_TYPE) {
+      ret_type = create_node(NODE_IDENTIFIER, token->value, NULL, NULL, NULL);
+      *token = next_token(lexer);
+    }
     if (token->type != TOKEN_IDENTIFIER) {
       fprintf(stderr, "Expected identifier after func\n");
       exit(1);
@@ -204,7 +211,7 @@ Node *parse_declaration(Lexer *lexer, Token *token) {
       fprintf(stderr, "Expected } after function body\n");
       exit(1);
     }
-      return create_node(NODE_FUNC_DEF, func_name, body, params, NULL);
+    return create_node(NODE_FUNC_DEF, func_name, body, params, ret_type);
   } else if (token->type == TOKEN_CLASS || token->type == TOKEN_STRUCT) {
     int is_struct = token->type == TOKEN_STRUCT;
     free(token->value);

--- a/tests/functions/definitions/functions.dr
+++ b/tests/functions/definitions/functions.dr
@@ -4,7 +4,7 @@ func PrintOne() {
 
 PrintOne();
 
-func GetTwo() {
+func int GetTwo() {
     return 2;
 }
 

--- a/tests/functions/definitions/typed_return.dr
+++ b/tests/functions/definitions/typed_return.dr
@@ -1,0 +1,4 @@
+func string Hello() {
+    return "hi";
+}
+Console.WriteLine(Hello());

--- a/tests/functions/parameters/function_params.dr
+++ b/tests/functions/parameters/function_params.dr
@@ -1,4 +1,4 @@
-func Add(int a, int b) {
+func int Add(int a, int b) {
     return a + b;
 }
 


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Implemented optional return types for functions. Parser now accepts a type after `func` and stores it in the AST. Code generation outputs the proper C return type and tracks function return types for expression classification. Documentation and tests were updated.

Related Files
- `src/parser/declaration.c`
- `src/codegen/codegen.c`
- `src/codegen/codegen.h`
- `src/driver/main.c`
- `docs/v1/functions.md`
- `docs/v1/changelog.md`
- `codex/FEATURES.md`
- `tests/functions/definitions/typed_return.dr`
- `tests/functions/definitions/functions.dr`
- `tests/functions/parameters/function_params.dr`

Changes
Added arrays in `Compiler` to track function return types. `generate_c_function` registers function names by type and writes `void` or typed signatures. Parser records optional return type tokens. Docs updated for syntax and example. New regression test ensures typed return works.

Testing
```bash
zig build
find tests -name '*.dr' | while read f; do zig build run -- "$f" || exit 1; done
```

Dependencies
None

Documentation
Updated `docs/v1/functions.md` and `docs/v1/changelog.md`.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [x] `codex/_startup.sh` updated if dependencies changed

Additional Notes
N/A

------
https://chatgpt.com/codex/tasks/task_e_6877fdd74430832baf8575bccb7656d5