### PR TITLE
Add basic C codegen scaffolding

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -33,6 +33,8 @@ pub fn build(b: *std.Build) void {
         "opt/dce.c",
         "opt/value_numbering.c",
         "opt/licm.c",
+        "codegen/c_emit.c",
+        "src/codegen/codegen.c",
     }, .flags = &.{
         "-std=c11",
         "-Wall",

--- a/codegen/c_emit.c
+++ b/codegen/c_emit.c
@@ -1,0 +1,111 @@
+#include "c_emit.h"
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+
+static void grow(COut *out, size_t needed) {
+    if (out->len + needed <= out->cap) return;
+    size_t new_cap = out->cap ? out->cap * 2 : 1024;
+    while (new_cap < out->len + needed) new_cap *= 2;
+    out->data = realloc(out->data, new_cap);
+    out->cap = new_cap;
+}
+
+void c_out_init(COut *out) {
+    out->data = NULL;
+    out->len = 0;
+    out->cap = 0;
+    out->indent = 0;
+    out->indent_width = 4;
+    out->at_line_start = 1;
+}
+
+void c_out_free(COut *out) { free(out->data); }
+
+void c_out_indent(COut *out) { out->indent++; }
+
+void c_out_dedent(COut *out) { if (out->indent > 0) out->indent--; }
+
+void c_out_newline(COut *out) {
+    grow(out, 2 + out->indent * out->indent_width);
+    out->data[out->len++] = '\n';
+    out->at_line_start = 1;
+}
+
+void c_out_write(COut *out, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    char buf[512];
+    int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    if (n < 0) return;
+    size_t needed = (size_t)n + 1 + (out->at_line_start ? out->indent * out->indent_width : 0);
+    grow(out, needed);
+    if (out->at_line_start) {
+        for (int i = 0; i < out->indent * out->indent_width; i++)
+            out->data[out->len++] = ' ';
+        out->at_line_start = 0;
+    }
+    memcpy(out->data + out->len, buf, (size_t)n);
+    out->len += (size_t)n;
+    out->data[out->len] = '\0';
+}
+
+void c_out_dump(FILE *f, COut *out) {
+    fwrite(out->data, 1, out->len, f);
+}
+
+static size_t find_decl(CDecl *decls, size_t ndecls, const char *name) {
+    for (size_t i = 0; i < ndecls; i++) {
+        if (strcmp(decls[i].name, name) == 0) return i;
+    }
+    return (size_t)-1;
+}
+
+static void visit(size_t idx, CDecl *decls, size_t ndecls,
+                  int *perm, int *temp, size_t *order, size_t *pos) {
+    if (perm[idx]) return;
+    if (temp[idx]) return; // ignore cycles
+    temp[idx] = 1;
+    CDecl *d = &decls[idx];
+    for (size_t i = 0; i < d->ndeps; i++) {
+        size_t j = find_decl(decls, ndecls, d->deps[i]);
+        if (j != (size_t)-1)
+            visit(j, decls, ndecls, perm, temp, order, pos);
+    }
+    perm[idx] = 1;
+    order[(*pos)++] = idx;
+}
+
+void cdecl_toposort(CDecl *decls, size_t ndecls, size_t *order) {
+    int *perm = calloc(ndecls, sizeof(int));
+    int *temp = calloc(ndecls, sizeof(int));
+    size_t pos = 0;
+    for (size_t i = 0; i < ndecls; i++)
+        visit(i, decls, ndecls, perm, temp, order, &pos);
+    free(perm);
+    free(temp);
+}
+
+char *c_mangle(const char *base, const char **types, size_t ntypes) {
+    size_t len = strlen(base);
+    for (size_t i = 0; i < ntypes; i++) len += 2 + strlen(types[i]);
+    char *res = malloc(len + 1);
+    char *p = stpcpy(res, base);
+    for (size_t i = 0; i < ntypes; i++) {
+        *p++ = '_'; *p++ = '_';
+        const char *t = types[i];
+        while (*t) {
+            char c = *t++;
+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                (c >= '0' && c <= '9')) {
+                *p++ = c;
+            } else {
+                *p++ = '_';
+            }
+        }
+    }
+    *p = '\0';
+    return res;
+}
+

--- a/codegen/c_emit.h
+++ b/codegen/c_emit.h
@@ -1,0 +1,45 @@
+#ifndef C_EMIT_H
+#define C_EMIT_H
+
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Indentation aware string builder */
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+    int indent;
+    int indent_width;
+    int at_line_start;
+} COut;
+
+void c_out_init(COut *out);
+void c_out_free(COut *out);
+void c_out_indent(COut *out);
+void c_out_dedent(COut *out);
+void c_out_write(COut *out, const char *fmt, ...);
+void c_out_newline(COut *out);
+void c_out_dump(FILE *f, COut *out);
+
+/* Generic name mangling */
+char *c_mangle(const char *base, const char **types, size_t ntypes);
+
+typedef struct CDecl CDecl;
+struct CDecl {
+    const char *name;
+    const char **deps;
+    size_t ndeps;
+};
+
+void cdecl_toposort(CDecl *decls, size_t ndecls, size_t *order);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -1,0 +1,19 @@
+#include "codegen.h"
+#include "../../codegen/c_emit.h"
+#include <stdio.h>
+
+void codegen_emit_c(Node *root, FILE *out) {
+    (void)root;
+    COut builder;
+    c_out_init(&builder);
+    c_out_write(&builder, "// TODO: implement code generation\n");
+    c_out_dump(out, &builder);
+    c_out_free(&builder);
+}
+
+void codegen_emit_obj(Node *root, const char *path) {
+    (void)root;
+    (void)path;
+    fprintf(stderr, "--emit-obj not implemented\n");
+}
+

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -1,3 +1,11 @@
 #ifndef CODEGEN_H
 #define CODEGEN_H
+
+#include "../parser/ast.h"
+#include <stdio.h>
+
+void codegen_emit_c(Node *root, FILE *out);
+void codegen_emit_obj(Node *root, const char *path);
+
 #endif
+

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -13,10 +13,32 @@
 
 int main(int argc, char *argv[]) {
     bool opt1 = false;
+    bool emit_c = true;
+    bool emit_obj = false;
     for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-O1") == 0 || strcmp(argv[i], "--O1") == 0)
+        if (strcmp(argv[i], "-O1") == 0 || strcmp(argv[i], "--O1") == 0) {
             opt1 = true;
+            continue;
+        }
+        if (strcmp(argv[i], "--emit-c") == 0) {
+            emit_c = true;
+            emit_obj = false;
+            continue;
+        }
+        if (strcmp(argv[i], "--emit-obj") == 0) {
+            emit_obj = true;
+            emit_c = false;
+            continue;
+        }
     }
+
     run_pipeline(NULL, opt1);
+
+    if (emit_c) {
+        codegen_emit_c(NULL, stdout);
+    } else if (emit_obj) {
+        codegen_emit_obj(NULL, "a.o");
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- add minimal `c_emit` utility with indentation-aware builder
- create placeholder codegen that uses `c_emit`
- update driver CLI with `--emit-c` and `--emit-obj`
- build new sources via `build.zig`

## Testing
- `zig build` *(no output indicates success)*
- `zig build test` *(fails: command exited with code 139)*

------
https://chatgpt.com/codex/tasks/task_e_68783cc6ed30832ba12ab853ca7fdc8b