### PR TITLE
Implement build.zig Dream build integration

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,28 @@
 const std = @import("std");
 
+fn compileDrSources(b: *std.Build, exe: *std.Build.Step.Compile) []std.Build.LazyPath {
+    const allocator = b.allocator;
+    var c_files = std.ArrayList(std.Build.LazyPath).init(allocator);
+    var src_dir = std.fs.cwd().openDir("src", .{ .iterate = true }) catch unreachable;
+    var it = src_dir.walk(allocator) catch unreachable;
+    while (it.next() catch unreachable) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.path, ".dr")) continue;
+        const in_path = b.pathJoin(&.{ "src", entry.path });
+        const run = b.addRunArtifact(exe);
+        run.addArg(in_path);
+        run.setEnvironmentVariable("SKIP_COMPILE", "1");
+        const base = std.fs.path.basename(entry.path);
+        const stem = std.fs.path.stem(base);
+        const out_lp = run.addOutputFileArg(b.fmt("{s}.c", .{stem}));
+        const out_path = out_lp.getPath2(b, &run.step);
+        run.setEnvironmentVariable("DREAM_OUT", out_path);
+        run.step.dependOn(b.getInstallStep());
+        c_files.append(out_lp) catch unreachable;
+    }
+    return c_files.toOwnedSlice() catch unreachable;
+}
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -45,4 +68,45 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run", "Build and run DreamCompiler");
     run_step.dependOn(&run_cmd.step);
+
+    const generated = compileDrSources(b, exe);
+    if (generated.len > 0) {
+        const prog_mod = b.createModule(.{ .target = target, .optimize = optimize });
+        const prog = b.addExecutable(.{ .name = "dream_program", .root_module = prog_mod });
+        for (generated) |g| {
+            prog.addCSourceFile(.{ .file = g, .flags = &.{"-std=c11"} });
+        }
+        prog.linkLibC();
+        b.installArtifact(prog);
+
+        const run_dream = b.addRunArtifact(prog);
+        if (b.args) |args| run_dream.addArgs(args);
+        const dr_step = b.step("rundr", "Build and run Dream program");
+        dr_step.dependOn(&run_dream.step);
+    }
+
+    const test_step = b.step("test", "Run regression tests");
+    var tdir = std.fs.cwd().openDir("tests", .{ .iterate = true }) catch unreachable;
+    var tit = tdir.walk(b.allocator) catch unreachable;
+    while (tit.next() catch unreachable) |e| {
+        if (e.kind != .file) continue;
+        if (!std.mem.endsWith(u8, e.path, ".dr")) continue;
+        const path = b.pathJoin(&.{ "tests", e.path });
+        const r = b.addRunArtifact(exe);
+        r.addArg(path);
+        r.step.dependOn(b.getInstallStep());
+        test_step.dependOn(&r.step);
+    }
+
+    const fmt_step = b.step("format", "Format C sources");
+    var sdir = std.fs.cwd().openDir("src", .{ .iterate = true }) catch unreachable;
+    var sit = sdir.walk(b.allocator) catch unreachable;
+    while (sit.next() catch unreachable) |f| {
+        if (f.kind != .file) continue;
+        const ext = std.fs.path.extension(f.path);
+        if (!std.mem.eql(u8, ext, ".c") and !std.mem.eql(u8, ext, ".h")) continue;
+        const fp = b.pathJoin(&.{ "src", f.path });
+        const cmd = b.addSystemCommand(&.{ "clang-format", "-i", fp });
+        fmt_step.dependOn(&cmd.step);
+    }
 }

--- a/docs/v1/changelog.md
+++ b/docs/v1/changelog.md
@@ -371,3 +371,9 @@ Version 1.0.68 (2025-08-16)
 * Functions can now declare an explicit return type after `func`.
 * Updated code generation to handle typed returns.
 * Added documentation and a regression test for typed return values.
+
+Version 1.0.69 (2025-08-21)
+
+* Integrated `.dr` -> `.c` build pipeline into `build.zig`.
+* Added `rundr`, `test` and `format` build steps.
+* Compiler now respects `DREAM_OUT` and `SKIP_COMPILE` environment variables.

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -1,6 +1,6 @@
+#include "../codegen/codegen.h"
 #include "../lexer/lexer.h"
 #include "../parser/parser.h"
-#include "../codegen/codegen.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,8 +39,26 @@ int main(int argc, char *argv[]) {
   mkdir("build", 0755);
   mkdir("build/bin", 0755);
 #endif
-  Compiler compiler = {fopen("build/bin/dream.c", "w"), NULL, 0, NULL, 0, NULL, 0, NULL, 0,
-                        NULL, 0, NULL, 0, NULL, 0, NULL, 0};
+  const char *out_path = getenv("DREAM_OUT");
+  if (!out_path)
+    out_path = "build/bin/dream.c";
+  Compiler compiler = {fopen(out_path, "w"),
+                       NULL,
+                       0,
+                       NULL,
+                       0,
+                       NULL,
+                       0,
+                       NULL,
+                       0,
+                       NULL,
+                       0,
+                       NULL,
+                       0,
+                       NULL,
+                       0,
+                       NULL,
+                       0};
   if (!compiler.output) {
     fprintf(stderr, "Failed to open output file\n");
     return 1;
@@ -118,11 +136,14 @@ int main(int argc, char *argv[]) {
   fclose(compiler.output);
   free(source);
   free(token.value);
-  const char *cc = getenv("CC");
-  if (!cc)
-    cc = "gcc";
-  char cmd[256];
-  snprintf(cmd, sizeof(cmd), "%s build/bin/dream.c -o build/bin/dream.exe", cc);
-  system(cmd);
+  const char *skip = getenv("SKIP_COMPILE");
+  if (!skip) {
+    const char *cc = getenv("CC");
+    if (!cc)
+      cc = "gcc";
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd), "%s %s -o build/bin/dream.exe", cc, out_path);
+    system(cmd);
+  }
   return 0;
 }


### PR DESCRIPTION
### Description
- add `compileDrSources` in `build.zig` to translate `.dr` files into C
- generate a runnable program from produced C and expose new `rundr` step
- add `test` and `format` build commands
- `DreamCompiler` now honors `DREAM_OUT` and `SKIP_COMPILE` env vars
- document build step in changelog

### Related Files
- `build.zig`
- `src/driver/main.c`
- `docs/v1/changelog.md`

### Changes
- compile `.dr` sources during build and run via Zig
- add regression test runner and formatting command
- support configurable output path and optional C compilation

### Testing
- `zig build`
- `zig build test`
- `zig build format`

### Dependencies
- none

### Documentation
- updated `docs/v1/changelog.md`

### Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed


------
https://chatgpt.com/codex/tasks/task_e_6878449e262c832baf02f97102bb471d