### PR TITLE
Fix missing stpcpy on non-GNU systems

### DIFF
--- a/src/codegen/c_emit.c
+++ b/src/codegen/c_emit.c
@@ -3,6 +3,16 @@
 #include <stdarg.h>
 #include <string.h>
 
+// `stpcpy` is a GNU extension and not universally available (e.g. on Windows).
+// Provide a small local implementation so the code compiles everywhere.
+static inline char *dream_stpcpy(char *dest, const char *src) {
+    while ((*dest = *src) != '\0') {
+        ++dest;
+        ++src;
+    }
+    return dest;
+}
+
 static void grow(COut *out, size_t needed) {
     if (out->len + needed <= out->cap) return;
     size_t new_cap = out->cap ? out->cap * 2 : 1024;
@@ -91,7 +101,7 @@ char *c_mangle(const char *base, const char **types, size_t ntypes) {
     size_t len = strlen(base);
     for (size_t i = 0; i < ntypes; i++) len += 2 + strlen(types[i]);
     char *res = malloc(len + 1);
-    char *p = stpcpy(res, base);
+    char *p = dream_stpcpy(res, base);
     for (size_t i = 0; i < ntypes; i++) {
         *p++ = '_'; *p++ = '_';
         const char *t = types[i];


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added an internal `dream_stpcpy` helper to replace the GNU-specific `stpcpy` in `c_emit.c`. This ensures the compiler builds on systems without the function (e.g. Windows).

Related Files
- `src/codegen/c_emit.c`

Changes
- Implemented `dream_stpcpy` as a local replacement.
- Updated `c_mangle` to use the new helper.

Testing
Executed:
```bash
zig build test
```
Tests failed in `tests/lexer` and `tests/parser` with segmentation faults.

Dependencies
No new dependencies.

Documentation
No docs changed.

Checklist
- [ ] `zig build` succeeds
- [ ] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
Tests currently fail with segmentation faults which appear unrelated to this patch.

------
https://chatgpt.com/codex/tasks/task_e_68784f619774832b85ffca527e7291fa