### PR TITLE
Add if statement parsing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,3 +4,4 @@ All notable changes to the Dream compiler will be documented in this file.
 
 ## [Unreleased]
 - Added automated test runner to `zig build test`.
+- Implemented parsing of `if`/`else` statements.

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -18,6 +18,7 @@ typedef enum {
     ND_IDENT,
     ND_BINOP,
     ND_VAR_DECL,
+    ND_IF,
     ND_BLOCK,
     ND_EXPR_STMT,
     ND_ERROR
@@ -46,6 +47,11 @@ struct Node {
             Slice name;
             Node *init;
         } var_decl;
+        struct {                      // ND_IF
+            Node *cond;
+            Node *then_br;
+            Node *else_br; // may be NULL
+        } if_stmt;
         struct {                      // ND_BLOCK
             Node **items;
             size_t len;


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Implemented parsing of if/else statements so the parser now supports conditional control flow. Updated changelog accordingly.

Related Files
Modified: `src/parser/ast.h`
Modified: `src/parser/parser.c`
Modified: `docs/changelog.md`

Changes
- Added `ND_IF` node type with fields for condition, then, and else branches.
- Implemented `parse_if` function and integrated it into `parse_stmt`.
- Documented the new feature in `docs/changelog.md`.

Testing
```bash
zig build --verbose
zig build test --verbose
```

Dependencies
None.

Documentation
Updated `docs/changelog.md` to mention the new parsing capability.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
No additional notes.

------
https://chatgpt.com/codex/tasks/task_e_68785ec18b40832ba05a42b067a9593a