### PR TITLE
Add basic C code generation

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -25,6 +25,7 @@
 - Console output via `Console.Write` and `Console.WriteLine`
 - String literals with escape sequences and concatenation using `+`
 - Line (`//`) and block (`/* */`) comments
+- Basic C code generation for programs
 
 ## Planned Features
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,3 +7,4 @@ All notable changes to the Dream compiler will be documented in this file.
 - Implemented parsing of `if`/`else` statements.
 - Lexer updated to recognise additional tokens (`??`, `??=`, `=>`, `::`, `->`,
   `&=`, `|=`, `^=`, `<<=`, `>>=`) per Grammar v0.3.
+- Added basic C code generation for programs.

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -2,18 +2,116 @@
 #include "c_emit.h"
 #include <stdio.h>
 
+static const char *op_text(TokenKind k) {
+  switch (k) {
+  case TK_PLUS:
+    return "+";
+  case TK_MINUS:
+    return "-";
+  case TK_STAR:
+    return "*";
+  case TK_SLASH:
+    return "/";
+  case TK_PERCENT:
+    return "%";
+  case TK_EQEQ:
+    return "==";
+  case TK_NEQ:
+    return "!=";
+  case TK_LT:
+    return "<";
+  case TK_GT:
+    return ">";
+  case TK_LTEQ:
+    return "<=";
+  case TK_GTEQ:
+    return ">=";
+  case TK_EQ:
+    return "=";
+  default:
+    return "?";
+  }
+}
+
+static void emit_expr(COut *b, Node *n);
+static void emit_stmt(COut *b, Node *n);
+
+static void emit_expr(COut *b, Node *n) {
+  switch (n->kind) {
+  case ND_INT:
+  case ND_STRING:
+    c_out_write(b, "%.*s", (int)n->as.lit.len, n->as.lit.start);
+    break;
+  case ND_IDENT:
+    c_out_write(b, "%.*s", (int)n->as.ident.len, n->as.ident.start);
+    break;
+  case ND_BINOP:
+    c_out_write(b, "(");
+    emit_expr(b, n->as.bin.lhs);
+    c_out_write(b, " %s ", op_text(n->as.bin.op));
+    emit_expr(b, n->as.bin.rhs);
+    c_out_write(b, ")");
+    break;
+  default:
+    c_out_write(b, "0");
+    break;
+  }
+}
+
+static void emit_stmt(COut *b, Node *n) {
+  switch (n->kind) {
+  case ND_VAR_DECL:
+    c_out_write(b, "int %.*s = ", (int)n->as.var_decl.name.len,
+                n->as.var_decl.name.start);
+    emit_expr(b, n->as.var_decl.init);
+    c_out_write(b, ";");
+    c_out_newline(b);
+    break;
+  case ND_IF:
+    c_out_write(b, "if (");
+    emit_expr(b, n->as.if_stmt.cond);
+    c_out_write(b, ") ");
+    emit_stmt(b, n->as.if_stmt.then_br);
+    if (n->as.if_stmt.else_br) {
+      c_out_write(b, " else ");
+      emit_stmt(b, n->as.if_stmt.else_br);
+    }
+    break;
+  case ND_BLOCK:
+    c_out_write(b, "{");
+    c_out_newline(b);
+    c_out_indent(b);
+    for (size_t i = 0; i < n->as.block.len; i++)
+      emit_stmt(b, n->as.block.items[i]);
+    c_out_dedent(b);
+    c_out_write(b, "}");
+    c_out_newline(b);
+    break;
+  case ND_EXPR_STMT:
+    emit_expr(b, n->as.expr_stmt.expr);
+    c_out_write(b, ";");
+    c_out_newline(b);
+    break;
+  default:
+    break;
+  }
+}
+
 void codegen_emit_c(Node *root, FILE *out) {
-    (void)root;
-    COut builder;
-    c_out_init(&builder);
-    c_out_write(&builder, "// TODO: implement code generation\n");
-    c_out_dump(out, &builder);
-    c_out_free(&builder);
+  COut builder;
+  c_out_init(&builder);
+  c_out_write(&builder, "#include <stdio.h>");
+  c_out_newline(&builder);
+  c_out_newline(&builder);
+  c_out_write(&builder, "int main(void) ");
+  emit_stmt(&builder, root);
+  c_out_newline(&builder);
+  c_out_dump(out, &builder);
+  c_out_free(&builder);
 }
 
 void codegen_emit_obj(Node *root, const char *path) {
-    (void)root;
-    (void)path;
-    fprintf(stderr, "--emit-obj not implemented\n");
+  (void)root;
+  (void)path;
+  fprintf(stderr, "--emit-obj not implemented\n");
 }
-


### PR DESCRIPTION
Dream Compiler Pull Request

**Description**
Implemented a minimal C code generator that traverses the AST and emits C code for variable declarations, expressions and simple control flow. Updated documentation to record the feature.

**Related Files**
Modified: `src/codegen/codegen.c`
Modified: `docs/changelog.md`
Modified: `codex/FEATURES.md`

**Changes**
- Added `emit_expr` and `emit_stmt` helpers to convert AST nodes into C syntax.
- `codegen_emit_c` now builds a full `main` function using these helpers.
- Documented the new capability in `docs/changelog.md` and `codex/FEATURES.md`.

**Testing**
- `zig build`
- `zig build test`

**Dependencies**
- None

**Documentation**
- Updated `docs/changelog.md`.
- Updated `codex/FEATURES.md`.

**Checklist**
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

**Additional Notes**
None.

------
https://chatgpt.com/codex/tasks/task_e_6878668392ec832b9df62bfcaf73d217