### PR TITLE
Implement object emission

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -26,6 +26,7 @@
 - String literals with escape sequences and concatenation using `+`
 - Line (`//`) and block (`/* */`) comments
 - Basic C code generation for programs
+- Object file output via `--emit-obj`
 
 ## Planned Features
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,3 +8,4 @@ All notable changes to the Dream compiler will be documented in this file.
 - Lexer updated to recognise additional tokens (`??`, `??=`, `=>`, `::`, `->`,
   `&=`, `|=`, `^=`, `<<=`, `>>=`) per Grammar v0.3.
 - Added basic C code generation for programs.
+- Implemented `--emit-obj` to compile generated C to an object file.


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Implemented basic object file emission and updated the driver to parse input files. The driver now reads a source file, builds an AST, and can emit either C code or an object file. `codegen_emit_obj` writes generated C to a temporary file and compiles it using `zig cc`.

Related Files
Modified: `src/driver/main.c`
Modified: `src/codegen/codegen.c`
Modified: `docs/changelog.md`
Modified: `codex/FEATURES.md`

Changes
- Added `read_file` helper and parsing logic in the driver.
- Implemented `codegen_emit_obj` using `mkstemps` and `zig cc`.
- Documented `--emit-obj` in changelog and features list.

Testing
- `zig build`
- `zig build test`

Dependencies
- None

Documentation
- Updated `docs/changelog.md` with new feature.
- Updated `codex/FEATURES.md`.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run` (placeholder tests pass)
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
Object emission uses a temporary file and assumes `zig cc` is available in PATH.

------
https://chatgpt.com/codex/tasks/task_e_6878680adbbc832bafe00dad803d7c31