### PR TITLE
Implement primitive type parsing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,3 +12,4 @@ All notable changes to the Dream compiler will be documented in this file.
 - Recognised `void` as reserved keyword per Grammar v0.3.
 - Fixed Windows build by replacing `mkstemps` with portable `tmpnam_s` fallback.
 - Restored generation of `build/bin/dream.c` when compiling `.dr` files.
+- Added support for primitive types (`int`, `float`, `char`, `bool`, `string`) in the parser and C code generation.

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -14,7 +14,10 @@ void *arena_alloc(Arena *a, size_t size);
 
 typedef enum {
     ND_INT,
+    ND_FLOAT,
+    ND_CHAR,
     ND_STRING,
+    ND_BOOL,
     ND_IDENT,
     ND_BINOP,
     ND_VAR_DECL,
@@ -36,7 +39,7 @@ Node *node_new(Arena *a, NodeKind kind);
 struct Node {
     NodeKind kind;
     union {
-        Slice lit;                    // ND_INT, ND_STRING
+        Slice lit;                    // ND_* literal nodes
         Slice ident;                  // ND_IDENT
         struct {                      // ND_BINOP
             TokenKind op;
@@ -44,6 +47,7 @@ struct Node {
             Node *rhs;
         } bin;
         struct {                      // ND_VAR_DECL
+            TokenKind type;
             Slice name;
             Node *init;
         } var_decl;


### PR DESCRIPTION
## Summary
- extend AST to include primitives and store declared types
- add typed variable parsing and bool/char/float literals
- generate C code for primitive types
- document primitive support in changelog

## Testing
- `zig build test`
- `zig build run -- tests/basics/types/char.dr`
- `zig build run -- tests/basics/types/bool.dr`
- `zig build run -- tests/basics/types/float.dr`

------
https://chatgpt.com/codex/tasks/task_e_6878855cf2f8832ba1f1c6b54c82021c