### PR TITLE
Add developer console macros

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -24,6 +24,7 @@
  - Functions with parameters and typed return values
 - Classes and structs with field access and object instantiation
 - Console output via `Console.Write` and `Console.WriteLine`
+- Developer macros `Console.Write`/`WriteLine` for compiler debugging (disabled in release)
 - String literals with escape sequences and concatenation using `+`
 - Line (`//`) and block (`/* */`) comments
 - Basic C code generation for programs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,3 +13,4 @@ All notable changes to the Dream compiler will be documented in this file.
 - Fixed Windows build by replacing `mkstemps` with portable `tmpnam_s` fallback.
 - Restored generation of `build/bin/dream.c` when compiling `.dr` files.
 - Added support for primitive types (`int`, `float`, `char`, `bool`, `string`) in the parser and C code generation.
+- Introduced developer-only `Console.Write`/`WriteLine` macros for compiler debugging.

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -1,11 +1,12 @@
-#include "../lexer/lexer.h"
-#include "../parser/parser.h"
 #include "../codegen/codegen.h"
+#include "../lexer/lexer.h"
+#include "../opt/pipeline.h"
 #include "../parser/diagnostic.h"
+#include "../parser/parser.h"
+#include "../util/console_debug.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../opt/pipeline.h"
 #ifdef _WIN32
 #include <direct.h>
 #else
@@ -13,91 +14,96 @@
 #endif
 
 static char *read_file(const char *path) {
-    FILE *f = fopen(path, "rb");
-    if (!f) return NULL;
-    fseek(f, 0, SEEK_END);
-    long len = ftell(f);
-    fseek(f, 0, SEEK_SET);
-    char *buf = malloc(len + 1);
-    if (!buf) {
-        fclose(f);
-        return NULL;
-    }
-    fread(buf, 1, len, f);
-    buf[len] = 0;
+  FILE *f = fopen(path, "rb");
+  if (!f)
+    return NULL;
+  fseek(f, 0, SEEK_END);
+  long len = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  char *buf = malloc(len + 1);
+  if (!buf) {
     fclose(f);
-    return buf;
+    return NULL;
+  }
+  fread(buf, 1, len, f);
+  buf[len] = 0;
+  fclose(f);
+  return buf;
 }
 
 int main(int argc, char *argv[]) {
-    bool opt1 = false;
-    bool emit_c = true;
-    bool emit_obj = false;
-    const char *input = NULL;
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-O1") == 0 || strcmp(argv[i], "--O1") == 0) {
-            opt1 = true;
-            continue;
-        }
-        if (strcmp(argv[i], "--emit-c") == 0) {
-            emit_c = true;
-            emit_obj = false;
-            continue;
-        }
-        if (strcmp(argv[i], "--emit-obj") == 0) {
-            emit_obj = true;
-            emit_c = false;
-            continue;
-        }
-        input = argv[i];
+  bool opt1 = false;
+  bool emit_c = true;
+  bool emit_obj = false;
+  const char *input = NULL;
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-O1") == 0 || strcmp(argv[i], "--O1") == 0) {
+      opt1 = true;
+      continue;
     }
-
-    if (!input) {
-        fprintf(stderr, "usage: %s [options] file\n", argv[0]);
-        return 1;
+    if (strcmp(argv[i], "--emit-c") == 0) {
+      emit_c = true;
+      emit_obj = false;
+      continue;
     }
-    char *src = read_file(input);
-    if (!src) {
-        perror("read_file");
-        return 1;
+    if (strcmp(argv[i], "--emit-obj") == 0) {
+      emit_obj = true;
+      emit_c = false;
+      continue;
     }
+    input = argv[i];
+  }
 
-    Arena arena; arena_init(&arena);
-    Parser p; parser_init(&p, &arena, src);
-    Node *root = parse_program(&p);
-    print_diagnostics(src, &p.diags);
+  if (!input) {
+    fprintf(stderr, "usage: %s [options] file\n", argv[0]);
+    return 1;
+  }
+  char *src = read_file(input);
+  if (!src) {
+    perror("read_file");
+    return 1;
+  }
 
-    run_pipeline(NULL, opt1);
+  Console.WriteLine("compiling %s", input);
 
-    if (emit_c) {
+  Arena arena;
+  arena_init(&arena);
+  Parser p;
+  parser_init(&p, &arena, src);
+  Node *root = parse_program(&p);
+  print_diagnostics(src, &p.diags);
+
+  run_pipeline(NULL, opt1);
+
+  if (emit_c) {
 #ifdef _WIN32
-        _mkdir("build");
-        _mkdir("build/bin");
+    _mkdir("build");
+    _mkdir("build/bin");
 #else
-        mkdir("build", 0755);
-        mkdir("build/bin", 0755);
+    mkdir("build", 0755);
+    mkdir("build/bin", 0755);
 #endif
-        FILE *out = fopen("build/bin/dream.c", "w");
-        if (!out) {
-            perror("fopen");
-            return 1;
-        }
-        codegen_emit_c(root, out);
-        fclose(out);
-        const char *cc = getenv("CC");
-        if (!cc)
-            cc = "zig cc";
-        char cmd[256];
-        snprintf(cmd, sizeof(cmd), "%s build/bin/dream.c -o dream", cc);
-        int res = system(cmd);
-        if (res != 0)
-            fprintf(stderr, "failed to run: %s\n", cmd);
-    } else if (emit_obj) {
-        codegen_emit_obj(root, "a.o");
+    FILE *out = fopen("build/bin/dream.c", "w");
+    if (!out) {
+      perror("fopen");
+      return 1;
     }
+    codegen_emit_c(root, out);
+    fclose(out);
+    const char *cc = getenv("CC");
+    if (!cc)
+      cc = "zig cc";
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd), "%s build/bin/dream.c -o dream", cc);
+    int res = system(cmd);
+    if (res != 0)
+      fprintf(stderr, "failed to run: %s\n", cmd);
+  } else if (emit_obj) {
+    codegen_emit_obj(root, "a.o");
+  }
 
-    free(src);
-    free(p.diags.data);
-    free(arena.ptr);
-    return 0;
+  free(src);
+  free(p.diags.data);
+  free(arena.ptr);
+  return 0;
 }

--- a/src/util/console_debug.h
+++ b/src/util/console_debug.h
@@ -1,0 +1,41 @@
+#ifndef CONSOLE_DEBUG_H
+#define CONSOLE_DEBUG_H
+#include <stdio.h>
+#include <stdarg.h>
+
+typedef struct ConsoleAPI {
+    void (*WriteLine)(const char *fmt, ...);
+    void (*Write)(const char *fmt, ...);
+} ConsoleAPI;
+
+#ifndef DREAM_RELEASE
+static inline void console_writeline_impl(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fputc('\n', stderr);
+}
+
+static inline void console_write_impl(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+}
+#else
+static inline void console_writeline_impl(const char *fmt, ...) {
+    (void)fmt;
+}
+static inline void console_write_impl(const char *fmt, ...) {
+    (void)fmt;
+}
+#endif
+
+static const ConsoleAPI Console = {
+    .WriteLine = console_writeline_impl,
+    .Write = console_write_impl,
+};
+
+#endif // CONSOLE_DEBUG_H
+


### PR DESCRIPTION
## Summary
- add `Console.WriteLine`/`Console.Write` macros for compiler debugging
- emit a debug message when compiling input files
- document developer macros in changelog and features list

## Testing
- `zig build`
- `for f in tests/*/*.dr; do zig build run -- "$f"; done` *(fails: unexpected tokens)*

------
https://chatgpt.com/codex/tasks/task_e_6878899a728c832b98f5d288b8611804