### PR TITLE
Fix newline handling in file reader

### DIFF
--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -20,12 +20,15 @@ static char *read_file(const char *path) {
   fseek(f, 0, SEEK_END);
   long len = ftell(f);
   fseek(f, 0, SEEK_SET);
-  char *buf = malloc(len + 1);
+  char *buf = malloc(len + 2);
   if (!buf) {
     fclose(f);
     return NULL;
   }
   fread(buf, 1, len, f);
+  if (len == 0 || buf[len - 1] != '\n') {
+    buf[len++] = '\n';
+  }
   buf[len] = 0;
   fclose(f);
   return buf;


### PR DESCRIPTION
Dream Compiler Pull Request

Description
- Fixed `read_file` to append a newline if the file does not end with one, preventing lexer crashes on EOF comments.

Related Files
- `src/driver/main.c`

Changes
- Adjusted allocation to `len + 2` and add newline when absent.

Testing
```bash
zig build
zig build run -- tests/basics/arithmetic/arithmetic.dr
```

Dependencies
- None

Documentation
- None

Checklist
- [ ] `zig build` succeeds
- [ ] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
- Compiler still reports parse errors for test programs; broader feature implementation is pending.

------
https://chatgpt.com/codex/tasks/task_e_68788c1eac18832b908b5f58aa70a691