### PR TITLE
Add while loop support

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -10,6 +10,7 @@
 - Parentheses for expression grouping
 - `if`/`else` statements
 - Nested block statements
+- `while` loops
 - Console output via `Console.Write` and `Console.WriteLine`
 - String and character literals with escape sequences
 - Line (`//`) and block (`/* */`) comments

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,3 +16,4 @@ All notable changes to the Dream compiler will be documented in this file.
 - Introduced developer-only `Console.Write`/`WriteLine` macros for compiler debugging.
 
 - Documented current feature gaps in codex/FEATURES.md and added tasks/TODO.md.
+- Added parsing and code generation for `while` loops.

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -113,6 +113,12 @@ static void emit_stmt(COut *b, Node *n) {
       emit_stmt(b, n->as.if_stmt.else_br);
     }
     break;
+  case ND_WHILE:
+    c_out_write(b, "while (");
+    emit_expr(b, n->as.while_stmt.cond);
+    c_out_write(b, ") ");
+    emit_stmt(b, n->as.while_stmt.body);
+    break;
   case ND_BLOCK:
     c_out_write(b, "{");
     c_out_newline(b);

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -22,6 +22,7 @@ typedef enum {
     ND_BINOP,
     ND_VAR_DECL,
     ND_IF,
+    ND_WHILE,
     ND_BLOCK,
     ND_EXPR_STMT,
     ND_ERROR
@@ -56,6 +57,10 @@ struct Node {
             Node *then_br;
             Node *else_br; // may be NULL
         } if_stmt;
+        struct {                      // ND_WHILE
+            Node *cond;
+            Node *body;
+        } while_stmt;
         struct {                      // ND_BLOCK
             Node **items;
             size_t len;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -66,6 +66,26 @@ static Node *parse_if(Parser *p) {
     return n;
 }
 
+static Node *parse_while(Parser *p) {
+    next(p); // consume 'while'
+    if (p->tok.kind != TK_LPAREN) {
+        diag_push(p, p->tok.pos, "expected '('");
+        return node_new(p->arena, ND_ERROR);
+    }
+    next(p);
+    Node *cond = parse_expr_prec(p, 0);
+    if (p->tok.kind != TK_RPAREN) {
+        diag_push(p, p->tok.pos, "expected ')'");
+    } else {
+        next(p);
+    }
+    Node *body = parse_stmt(p);
+    Node *n = node_new(p->arena, ND_WHILE);
+    n->as.while_stmt.cond = cond;
+    n->as.while_stmt.body = body;
+    return n;
+}
+
 static Node *parse_primary(Parser *p) {
     Token t = p->tok;
     Node *n;
@@ -225,6 +245,9 @@ static void nodevec_push(Node ***data, size_t *len, size_t *cap, Node *n) {
 static Node *parse_stmt(Parser *p) {
     if (p->tok.kind == TK_KW_IF) {
         return parse_if(p);
+    }
+    if (p->tok.kind == TK_KW_WHILE) {
+        return parse_while(p);
     }
     if (is_type_token(p->tok.kind)) {
         return parse_var_decl(p);

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -1,9 +1,9 @@
 # Outstanding Tasks
 
-The grammar specification in `docs/grammar/Grammar.md` lists several language features such as loops, switch statements, and return/break/continue statements as *implemented*. The current parser only supports variable declarations, `if`/`else` statements, and expression statements.
+The grammar specification in `docs/grammar/Grammar.md` lists several language features such as loops, switch statements, and return/break/continue statements as *implemented*. The current parser now supports `while` loops in addition to variable declarations, `if`/`else` statements, and expression statements.
 
 Future work:
-- Implement parsing and code generation for loops (`while`, `do`, `for`).
+- Implement parsing and code generation for remaining loops (`do`, `for`).
 - Add support for `switch` statements, `break`, `continue`, and `return`.
 - Extend the AST and code generator accordingly.
 - Update the grammar once features land to keep it authoritative.


### PR DESCRIPTION
## Summary
- extend AST with `ND_WHILE`
- parse `while` statements in parser
- generate C code for while loops
- document new feature in FEATURES.md
- update changelog
- adjust TODO list

## Testing
- `zig build`
- `zig build test`


------
https://chatgpt.com/codex/tasks/task_e_68788f473f5c832bb8004858a14b9690