### PR TITLE
Fix Console.Write output

### DIFF
--- a/src/lexer/lexer.re
+++ b/src/lexer/lexer.re
@@ -73,8 +73,8 @@ static Token lex_raw(Lexer *lx) {
         /* use default YYGETCONDITION/YYSETCONDITION macros */
         re2c:yyfill:enable = 0;
     */
+    tok_start = lx->cursor;
     for (;;) {
-        tok_start = lx->cursor;
         if (lx->cursor >= lx->limit)
             return make_token(lx, TK_EOF, lx->cursor, 0);
         /*!re2c


### PR DESCRIPTION
## Summary
- preserve string token start when lexing
- quote string literals during C emission
- treat `Console.Write*` expressions inside expression statements

## Testing
- `zig build run -- /tmp/tmp2.dr`
- `zig build run -- tests/basics/io/write.dr`
- `zig build run -- tests/basics/io/console.dr`
- `zig build test`

------
https://chatgpt.com/codex/tasks/task_e_687893ceb350832b978fd65b7b1639d0