### PR TITLE
Implement break statements

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -11,6 +11,7 @@
 - `if`/`else` statements
 - Nested block statements
 - `while` loops
+- `break` statements
 - Console output via `Console.Write` and `Console.WriteLine`
 - String and character literals with escape sequences
 - Line (`//`) and block (`/* */`) comments

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,3 +17,4 @@ All notable changes to the Dream compiler will be documented in this file.
 
 - Documented current feature gaps in codex/FEATURES.md and added tasks/TODO.md.
 - Added parsing and code generation for `while` loops.
+- Implemented `break` statements.

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -134,6 +134,10 @@ static void emit_stmt(COut *b, Node *n) {
     c_out_write(b, ") ");
     emit_stmt(b, n->as.while_stmt.body);
     break;
+  case ND_BREAK:
+    c_out_write(b, "break;");
+    c_out_newline(b);
+    break;
   case ND_BLOCK:
     c_out_write(b, "{");
     c_out_newline(b);

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -23,6 +23,7 @@ typedef enum {
     ND_VAR_DECL,
     ND_IF,
     ND_WHILE,
+    ND_BREAK,
     ND_BLOCK,
     ND_EXPR_STMT,
     ND_CONSOLE_CALL,

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -86,6 +86,16 @@ static Node *parse_while(Parser *p) {
     return n;
 }
 
+static Node *parse_break(Parser *p) {
+    next(p); // consume 'break'
+    if (p->tok.kind == TK_SEMICOLON) {
+        next(p);
+    } else {
+        diag_push(p, p->tok.pos, "expected ';'");
+    }
+    return node_new(p->arena, ND_BREAK);
+}
+
 static Node *parse_primary(Parser *p) {
     Token t = p->tok;
     Node *n;
@@ -280,6 +290,9 @@ static Node *parse_stmt(Parser *p) {
     }
     if (p->tok.kind == TK_KW_WHILE) {
         return parse_while(p);
+    }
+    if (p->tok.kind == TK_KW_BREAK) {
+        return parse_break(p);
     }
     if (is_type_token(p->tok.kind)) {
         return parse_var_decl(p);

--- a/tests/control_flow/loops/break.dr
+++ b/tests/control_flow/loops/break.dr
@@ -1,0 +1,6 @@
+int i = 0;
+while (true) {
+    break;
+    i = 1;
+}
+Console.WriteLine(i); // Expected: 0


### PR DESCRIPTION
## Summary
- support `break` statements in parser
- emit `break;` in C code generation
- document the new feature and add changelog entry
- add regression test for break

## Testing
- `zig build`
- `zig build test`
- `zig build run -- tests/control_flow/loops/break.dr`

------
https://chatgpt.com/codex/tasks/task_e_687896efa590832b9d760e31d052cde7