### PR TITLE
[dreamc] Implement bitwise operators

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -20,13 +20,14 @@
 - String and character literals with escape sequences
 - Line (`//`) and block (`/* */`) comments
 - Basic C code generation for programs
+- Bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`)
 
 ## Missing Features
 
 The following language constructs appear in the documentation or tests but are not yet implemented:
 
 - Arrays of any type
-- Bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`) and compound assignments
+- Compound assignment operators for arithmetic and bitwise operations
 - Increment/decrement operators `++` and `--`
 - Ternary conditional operator `?:`
 - `for` loops

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ All notable changes to the Dream compiler will be documented in this file.
 
 ## [Unreleased]
 - Added automated test runner to `zig build test`.
+- Implemented bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`).
 - Implemented parsing of `if`/`else` statements.
 - Lexer updated to recognise additional tokens (`??`, `??=`, `=>`, `::`, `->`,
   `&=`, `|=`, `^=`, `<<=`, `>>=`) per Grammar v0.3.

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -21,6 +21,16 @@ static const char *op_text(TokenKind k) {
     return "/";
   case TK_PERCENT:
     return "%";
+  case TK_OR:
+    return "|";
+  case TK_CARET:
+    return "^";
+  case TK_AND:
+    return "&";
+  case TK_LSHIFT:
+    return "<<";
+  case TK_RSHIFT:
+    return ">>";
   case TK_ANDAND:
     return "&&";
   case TK_OROR:

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -257,7 +257,8 @@ static Node *parse_primary(Parser *p) {
 }
 
 static Node *parse_unary(Parser *p) {
-  if (p->tok.kind == TK_MINUS || p->tok.kind == TK_BANG) {
+  if (p->tok.kind == TK_MINUS || p->tok.kind == TK_BANG ||
+      p->tok.kind == TK_TILDE) {
     TokenKind op = p->tok.kind;
     next(p);
     Node *expr = parse_unary(p);
@@ -308,13 +309,22 @@ static int precedence(TokenKind k) {
   case TK_GT:
   case TK_LTEQ:
   case TK_GTEQ:
-    return 4;
+    return 7;
+  case TK_LSHIFT:
+  case TK_RSHIFT:
+    return 8;
   case TK_PLUS:
   case TK_MINUS:
-    return 5;
+    return 9;
   case TK_STAR:
   case TK_SLASH:
   case TK_PERCENT:
+    return 10;
+  case TK_OR:
+    return 4;
+  case TK_CARET:
+    return 5;
+  case TK_AND:
     return 6;
   default:
     return -1;


### PR DESCRIPTION
## What changed
- support bitwise operators in parser and codegen
- document bitwise support and update changelog

## How it was tested
- `zig build`
- `zig build test`


------
https://chatgpt.com/codex/tasks/task_e_6878a5941e50832bb41fe5aa9c95683b