### PR TITLE
[dreamc] Implement string concatenation

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -24,6 +24,7 @@
 - Bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`)
 - Compound assignment operators (`+=`, `-=`, `*=`, `/=`, `%=` and bitwise variants)
 - Increment/decrement operators `++` and `--`
+- String concatenation with `+`
 
 ## Missing Features
 
@@ -34,6 +35,5 @@
 - `switch` statements
 - Function declarations with parameters and typed return values
 - Classes, structs and object construction
-- String concatenation
 
 These features need implementing before they will compile without diagnostics.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,3 +24,4 @@ All notable changes to the Dream compiler will be documented in this file.
 - Implemented `continue` and `return` statements.
 - Added prefix/postfix increment and decrement operators.
 - Added compound assignment operators for arithmetic and bitwise ops.
+- Added string concatenation for `string` values.

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -95,10 +95,58 @@ static const char *fmt_for_arg(Node *arg) {
   }
 }
 
-static void emit_expr(COut *b, Node *n);
-static void emit_stmt(COut *b, Node *n);
+typedef struct {
+  const char *start;
+  size_t len;
+  TokenKind type;
+  int depth;
+} VarBinding;
 
-static void emit_expr(COut *b, Node *n) {
+typedef struct {
+  VarBinding *vars;
+  size_t len;
+  size_t cap;
+  int depth;
+} CGCtx;
+
+static void cgctx_push(CGCtx *ctx, const char *start, size_t len, TokenKind ty) {
+  if (ctx->len + 1 > ctx->cap) {
+    ctx->cap = ctx->cap ? ctx->cap * 2 : 8;
+    ctx->vars = realloc(ctx->vars, ctx->cap * sizeof(VarBinding));
+  }
+  ctx->vars[ctx->len++] = (VarBinding){start, len, ty, ctx->depth};
+}
+
+static void cgctx_scope_enter(CGCtx *ctx) { ctx->depth++; }
+
+static void cgctx_scope_leave(CGCtx *ctx) {
+  while (ctx->len && ctx->vars[ctx->len - 1].depth >= ctx->depth) ctx->len--;
+  if (ctx->depth > 0) ctx->depth--;
+}
+
+static TokenKind cgctx_lookup(CGCtx *ctx, const char *start, size_t len) {
+  for (size_t i = ctx->len; i-- > 0;) {
+    VarBinding *v = &ctx->vars[i];
+    if (v->len == len && strncmp(v->start, start, len) == 0) return v->type;
+  }
+  return (TokenKind)0;
+}
+
+static int is_string_expr(CGCtx *ctx, Node *n) {
+  switch (n->kind) {
+  case ND_STRING:
+    return 1;
+  case ND_IDENT:
+    return cgctx_lookup(ctx, n->as.ident.start, n->as.ident.len) == TK_KW_STRING;
+  default:
+    return 0;
+  }
+}
+
+static void emit_expr(CGCtx *ctx, COut *b, Node *n);
+static void emit_stmt(CGCtx *ctx, COut *b, Node *n);
+
+static void emit_expr(CGCtx *ctx, COut *b, Node *n) {
   switch (n->kind) {
   case ND_INT:
   case ND_FLOAT:
@@ -124,20 +172,30 @@ static void emit_expr(COut *b, Node *n) {
   case ND_UNARY:
     c_out_write(b, "(");
     c_out_write(b, "%s", op_text(n->as.unary.op));
-    emit_expr(b, n->as.unary.expr);
+    emit_expr(ctx, b, n->as.unary.expr);
     c_out_write(b, ")");
     break;
   case ND_POST_UNARY:
     c_out_write(b, "(");
-    emit_expr(b, n->as.unary.expr);
+    emit_expr(ctx, b, n->as.unary.expr);
     c_out_write(b, "%s", op_text(n->as.unary.op));
     c_out_write(b, ")");
     break;
   case ND_BINOP:
     c_out_write(b, "(");
-    emit_expr(b, n->as.bin.lhs);
-    c_out_write(b, " %s ", op_text(n->as.bin.op));
-    emit_expr(b, n->as.bin.rhs);
+    if (n->as.bin.op == TK_PLUS &&
+        (is_string_expr(ctx, n->as.bin.lhs) ||
+         is_string_expr(ctx, n->as.bin.rhs))) {
+      c_out_write(b, "dream_concat(");
+      emit_expr(ctx, b, n->as.bin.lhs);
+      c_out_write(b, ", ");
+      emit_expr(ctx, b, n->as.bin.rhs);
+      c_out_write(b, ")");
+    } else {
+      emit_expr(ctx, b, n->as.bin.lhs);
+      c_out_write(b, " %s ", op_text(n->as.bin.op));
+      emit_expr(ctx, b, n->as.bin.rhs);
+    }
     c_out_write(b, ")");
     break;
   default:
@@ -163,36 +221,38 @@ static const char *type_to_c(TokenKind k) {
   }
 }
 
-static void emit_stmt(COut *b, Node *n) {
+static void emit_stmt(CGCtx *ctx, COut *b, Node *n) {
   switch (n->kind) {
   case ND_VAR_DECL:
     c_out_write(b, "%s %.*s = ", type_to_c(n->as.var_decl.type),
                 (int)n->as.var_decl.name.len, n->as.var_decl.name.start);
-    emit_expr(b, n->as.var_decl.init);
+    emit_expr(ctx, b, n->as.var_decl.init);
+    cgctx_push(ctx, n->as.var_decl.name.start, n->as.var_decl.name.len,
+               n->as.var_decl.type);
     c_out_write(b, ";");
     c_out_newline(b);
     break;
   case ND_IF:
     c_out_write(b, "if (");
-    emit_expr(b, n->as.if_stmt.cond);
+    emit_expr(ctx, b, n->as.if_stmt.cond);
     c_out_write(b, ") ");
-    emit_stmt(b, n->as.if_stmt.then_br);
+    emit_stmt(ctx, b, n->as.if_stmt.then_br);
     if (n->as.if_stmt.else_br) {
       c_out_write(b, " else ");
-      emit_stmt(b, n->as.if_stmt.else_br);
+      emit_stmt(ctx, b, n->as.if_stmt.else_br);
     }
     break;
   case ND_WHILE:
     c_out_write(b, "while (");
-    emit_expr(b, n->as.while_stmt.cond);
+    emit_expr(ctx, b, n->as.while_stmt.cond);
     c_out_write(b, ") ");
-    emit_stmt(b, n->as.while_stmt.body);
+    emit_stmt(ctx, b, n->as.while_stmt.body);
     break;
   case ND_DO_WHILE:
     c_out_write(b, "do ");
-    emit_stmt(b, n->as.do_while_stmt.body);
+    emit_stmt(ctx, b, n->as.do_while_stmt.body);
     c_out_write(b, " while (");
-    emit_expr(b, n->as.do_while_stmt.cond);
+    emit_expr(ctx, b, n->as.do_while_stmt.cond);
     c_out_write(b, ");");
     c_out_newline(b);
     break;
@@ -204,19 +264,22 @@ static void emit_stmt(COut *b, Node *n) {
                     type_to_c(n->as.for_stmt.init->as.var_decl.type),
                     (int)n->as.for_stmt.init->as.var_decl.name.len,
                     n->as.for_stmt.init->as.var_decl.name.start);
-        emit_expr(b, n->as.for_stmt.init->as.var_decl.init);
+        emit_expr(ctx, b, n->as.for_stmt.init->as.var_decl.init);
+        cgctx_push(ctx, n->as.for_stmt.init->as.var_decl.name.start,
+                   n->as.for_stmt.init->as.var_decl.name.len,
+                   n->as.for_stmt.init->as.var_decl.type);
       } else {
-        emit_expr(b, n->as.for_stmt.init);
+        emit_expr(ctx, b, n->as.for_stmt.init);
       }
     }
     c_out_write(b, "; ");
     if (n->as.for_stmt.cond)
-      emit_expr(b, n->as.for_stmt.cond);
+      emit_expr(ctx, b, n->as.for_stmt.cond);
     c_out_write(b, "; ");
     if (n->as.for_stmt.update)
-      emit_expr(b, n->as.for_stmt.update);
+      emit_expr(ctx, b, n->as.for_stmt.update);
     c_out_write(b, ") ");
-    emit_stmt(b, n->as.for_stmt.body);
+    emit_stmt(ctx, b, n->as.for_stmt.body);
     break;
   case ND_BREAK:
     c_out_write(b, "break;");
@@ -230,7 +293,7 @@ static void emit_stmt(COut *b, Node *n) {
     c_out_write(b, "return");
     if (n->as.ret.expr) {
       c_out_write(b, " ");
-      emit_expr(b, n->as.ret.expr);
+      emit_expr(ctx, b, n->as.ret.expr);
     }
     c_out_write(b, ";");
     c_out_newline(b);
@@ -239,8 +302,10 @@ static void emit_stmt(COut *b, Node *n) {
     c_out_write(b, "{");
     c_out_newline(b);
     c_out_indent(b);
+    cgctx_scope_enter(ctx);
     for (size_t i = 0; i < n->as.block.len; i++)
-      emit_stmt(b, n->as.block.items[i]);
+      emit_stmt(ctx, b, n->as.block.items[i]);
+    cgctx_scope_leave(ctx);
     c_out_dedent(b);
     c_out_write(b, "}");
     c_out_newline(b);
@@ -253,11 +318,11 @@ static void emit_stmt(COut *b, Node *n) {
       if (call->as.console.newline)
         c_out_write(b, "\\n");
       c_out_write(b, "\", ");
-      emit_expr(b, call->as.console.arg);
+      emit_expr(ctx, b, call->as.console.arg);
       c_out_write(b, ");");
       c_out_newline(b);
     } else {
-      emit_expr(b, n->as.expr_stmt.expr);
+      emit_expr(ctx, b, n->as.expr_stmt.expr);
       c_out_write(b, ";");
       c_out_newline(b);
     }
@@ -268,7 +333,7 @@ static void emit_stmt(COut *b, Node *n) {
     if (n->as.console.newline)
       c_out_write(b, "\\n");
     c_out_write(b, "\", ");
-    emit_expr(b, n->as.console.arg);
+    emit_expr(ctx, b, n->as.console.arg);
     c_out_write(b, ");");
     c_out_newline(b);
     break;
@@ -282,9 +347,28 @@ void codegen_emit_c(Node *root, FILE *out) {
   c_out_init(&builder);
   c_out_write(&builder, "#include <stdio.h>");
   c_out_newline(&builder);
+  c_out_write(&builder, "#include <string.h>");
+  c_out_newline(&builder);
+  c_out_write(&builder, "#include <stdlib.h>");
+  c_out_newline(&builder);
+  c_out_newline(&builder);
+  c_out_write(&builder,
+              "static char *dream_concat(const char *a, const char *b) {\n");
+  c_out_write(&builder, "    size_t la = strlen(a);\n");
+  c_out_write(&builder, "    size_t lb = strlen(b);\n");
+  c_out_write(&builder, "    char *r = malloc(la + lb + 1);\n");
+  c_out_write(&builder, "    memcpy(r, a, la);\n");
+  c_out_write(&builder, "    memcpy(r + la, b, lb);\n");
+  c_out_write(&builder, "    r[la + lb] = 0;\n");
+  c_out_write(&builder, "    return r;\n}");
+  c_out_newline(&builder);
   c_out_newline(&builder);
   c_out_write(&builder, "int main(void) ");
-  emit_stmt(&builder, root);
+  CGCtx ctx = {0};
+  cgctx_scope_enter(&ctx);
+  emit_stmt(&ctx, &builder, root);
+  cgctx_scope_leave(&ctx);
+  free(ctx.vars);
   c_out_newline(&builder);
   c_out_dump(out, &builder);
   c_out_free(&builder);

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -7,6 +7,5 @@ The test suite shows many language constructs are still missing. The following f
 - Functions with parameters and typed return values
 - Classes, structs and object creation
 - The ternary `?:` operator
-- String concatenation
 
 Keep the grammar and documentation up to date once these features land.


### PR DESCRIPTION
## What changed
- added `dream_concat` runtime helper and variable tracking in `codegen.c`
- emit `dream_concat` when `+` is used on strings
- documented string concatenation as implemented
- removed completed item from TODO list

## How it was tested
- `zig build test` (no output)

## Docs updated
- `docs/changelog.md`
- `codex/FEATURES.md`

## Dependencies
- none

------
https://chatgpt.com/codex/tasks/task_e_6878adda2788832b9cd2364bfa7131e6