### PR TITLE
[dreamc] Add basic switch statement support

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -26,13 +26,13 @@
 - Increment/decrement operators `++` and `--`
 - String concatenation with `+`
 - Ternary conditional operator `?:`
+- `switch` statements
 
 ## Missing Features
 
 - The following language constructs appear in the documentation or tests but are not yet implemented:
 
 - Arrays of any type
-- `switch` statements
 - Function declarations with parameters and typed return values
 - Classes, structs and object construction
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,3 +27,4 @@ All notable changes to the Dream compiler will be documented in this file.
 - Added string concatenation for `string` values.
 - Implemented ternary conditional operator `?:`.
 - Added unary plus operator and enabled comparison operators.
+- Implemented basic `switch` statements in parser and code generator.

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -33,12 +33,12 @@ typedef enum {
   ND_RETURN,
   ND_BLOCK,
   ND_EXPR_STMT,
+  ND_SWITCH,
   ND_CONSOLE_CALL,
   ND_ERROR
 } NodeKind;
 
 typedef struct Node Node;
-
 typedef struct {
   const char *start;
   size_t len;
@@ -46,16 +46,22 @@ typedef struct {
 
 Node *node_new(Arena *a, NodeKind kind);
 
+typedef struct {
+  int is_default;
+  Node *value; // NULL if default
+  Node *body;
+} SwitchCase;
+
 struct Node {
   NodeKind kind;
   union {
     Slice lit;   // ND_* literal nodes
     Slice ident; // ND_IDENT
-    struct { // ND_UNARY and ND_POST_UNARY
+    struct {     // ND_UNARY and ND_POST_UNARY
       TokenKind op;
       Node *expr;
     } unary;
-    struct {     // ND_BINOP
+    struct { // ND_BINOP
       TokenKind op;
       Node *lhs;
       Node *rhs;
@@ -83,9 +89,9 @@ struct Node {
       Node *body;
       Node *cond;
     } do_while_stmt;
-    struct { // ND_FOR
-      Node *init;  // may be NULL
-      Node *cond;  // may be NULL
+    struct {        // ND_FOR
+      Node *init;   // may be NULL
+      Node *cond;   // may be NULL
       Node *update; // may be NULL
       Node *body;
     } for_stmt;
@@ -103,6 +109,11 @@ struct Node {
       Node *arg;
       int newline;
     } console;
+    struct { // ND_SWITCH
+      Node *expr;
+      SwitchCase *cases;
+      size_t len;
+    } switch_stmt;
     /* ND_CONTINUE has no fields */
   } as;
 };


### PR DESCRIPTION
## What changed
- introduce `ND_SWITCH` AST node and related `SwitchCase` structure
- implement parsing of `switch` statements
- emit `switch` constructs in the C code generator
- document the feature in `FEATURES.md` and `docs/changelog.md`

## How it was tested
- `clang-format -i src/parser/ast.h src/parser/parser.c src/codegen/codegen.c`
- `zig fmt --check build.zig`
- `zig build`
- `zig build test`


------
https://chatgpt.com/codex/tasks/task_e_6878b5ca72f8832b851a08d85a1f4e92