### PR TITLE
[dreamc] mark bitwise NOT operator implemented

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ All notable changes to the Dream compiler will be documented in this file.
 ## [Unreleased]
 - Added automated test runner to `zig build test`.
 - Implemented bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`).
+- Bitwise NOT `~` operator is now documented as implemented.
 - Implemented parsing of `if`/`else` statements.
 - Lexer updated to recognise additional tokens (`??`, `??=`, `=>`, `::`, `->`,
   `&=`, `|=`, `^=`, `<<=`, `>>=`) per Grammar v0.3.

--- a/docs/grammar/Grammar.md
+++ b/docs/grammar/Grammar.md
@@ -14,7 +14,7 @@ Sources: core grammar from the v0.2 draft; extended lexical grammar (§6) and sy
 * Integrated **Syntactic grammar** additions (namespaces, generics, attributes, patterns, lambdas, queries, etc.) as forward‑looking references.
 * Integrated **Unsafe grammar** additions (pointer types & ops, `fixed`, address‑of, fixed‑size buffers) as reserved constructs.
 * Added missing core tokens (`float`, `char`, `void` return via omission) and clarified built‑in `Console.Write`/`WriteLine`.
-* Cleaned up operator table formatting; added bitwise NOT `~` (reserved).
+* Cleaned up operator table formatting; bitwise NOT `~` is now implemented.
 
 ---
 
@@ -58,7 +58,7 @@ The combined token set recognised by the lexer includes all C# operators and pun
 | `=`                                 |   Implemented  | Simple assign.                                   |                                  |                        |
 | `? :`                               |   Implemented  | Conditional operator.                            |                                  |                        |
 | `<<` `>>`                           |   Implemented  | Shift.                                           |                                  |                        |
-| `~`                                 |     Partial    | Bitwise complement (reserved).                   |                                  |                        |
+| `~`                                 |   Implemented  | Bitwise complement.                             |                                  |
 | `??` `??=`                          |     Partial    | Null‑coalescing (future).                        |                                  |                        |
 | `=>`                                |     Partial    | Lambda / switch expr / property bodies (future). |                                  |                        |
 | `::`                                |     Partial    | Alias qualifier (future).                        |                                  |                        |


### PR DESCRIPTION
## Summary
- document that `~` is a fully supported operator

## Testing
- `zig build test`

------
https://chatgpt.com/codex/tasks/task_e_687977c899f0832b984676ab0217de72