### PR TITLE
[dreamc] restore language docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ An example program is provided in [example.dr](example.dr).
 
 ## Documentation
 
-Documentation for language features lives under [`docs`](docs). Start with [index.md](docs/index.md) to browse the available guides.
+Documentation lives under [`docs`](docs). Open [docs/index.html](docs/index.html) in a browser or read [docs/index.md](docs/index.md) directly.
 
-See [Source Architecture](docs/v1/architecture.md) for an overview of the compiler layout.
+See [Compiler Docs](docs/compiler/index.md) for compiler information and [Dream.dr Language](docs/language/index.md) for language guides.
 ## Contributing
 
 Contributions are welcome. Document any new language feature under `docs/` with a matching test case in `tests/`. Add additional dependencies to [`codex/_startup.sh`](codex/_startup.sh) if required.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,4 @@
+# Source Architecture
+
+The Dream compiler is split into focused directories such as `lexer/`, `parser/` and `codegen/`. Each module handles a single concern to keep the codebase maintainable.
+

--- a/docs/arithmetic.md
+++ b/docs/arithmetic.md
@@ -1,0 +1,4 @@
+# Arithmetic
+
+Dream.dr currently supports `+`, `-`, `*`, `/` and `%` along with bitwise operators. Expressions follow standard C precedence rules.
+

--- a/docs/arrays.md
+++ b/docs/arrays.md
@@ -1,0 +1,4 @@
+# Arrays *(planned)*
+
+Support for array types is planned but not yet implemented. Future versions will allow fixed-length arrays using bracket syntax similar to C.
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@
 All notable changes to the Dream compiler will be documented in this file.
 
 ## [Unreleased]
+- Documentation site rebuilt. `index.html` now loads `index.md` and navigation focuses on compiler and language guides.
+- Restored language documentation pages and detailed table of contents.
 - Added automated test runner to `zig build test`.
 - Implemented bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`).
 - Bitwise NOT `~` operator is now documented as implemented.

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -1,0 +1,4 @@
+# Classes *(planned)*
+
+Object oriented features including classes and methods are on the long term roadmap for Dream.dr.
+

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,0 +1,4 @@
+# Comments *(planned)*
+
+Single line comments using `//` are recognised. Block comments will be added later.
+

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,4 @@
+# Comparison *(planned)*
+
+Equality and relational operators will allow comparing numbers and strings. Implementation work has not started yet.
+

--- a/docs/compiler/index.md
+++ b/docs/compiler/index.md
@@ -1,0 +1,5 @@
+# Dream Compiler
+
+This section documents how to build and use the Dream compiler. It also covers the high level architecture of the project.
+
+Additional pages will be added here as the compiler grows.

--- a/docs/conditional.md
+++ b/docs/conditional.md
@@ -1,0 +1,4 @@
+# Conditional Operator *(planned)*
+
+The ternary `?:` operator will evaluate an expression based on a condition. It is not yet available in Dream.dr.
+

--- a/docs/console.md
+++ b/docs/console.md
@@ -1,0 +1,4 @@
+# Console Output *(planned)*
+
+A standard library for console I/O will provide `Console.WriteLine` and similar routines. Until then, output functions are stubbed.
+

--- a/docs/if.md
+++ b/docs/if.md
@@ -1,0 +1,4 @@
+# If Statements *(planned)*
+
+Conditional execution using `if` and `else` will be added to control flow.
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,42 +13,55 @@
     <aside class="sidebar">
         <nav class="nav">
             <h2>Documentation</h2>
-            <label for="version-select" class="version-label">Version:</label>
-            <select id="version-select">
-                <option value="v1" selected>v1</option>
-            </select>
             <ul>
-                <li class="category"><span>Getting Started</span>
+                <li><a href="#" data-md="index.md">Home</a></li>
+                <li class="category"><span>Compiler</span>
                     <ul>
-                        <li><a href="#" data-md="intro.md">Introduction</a></li>
-                        <li><a href="#" data-md="usage.md">Usage Guide</a></li>
+                        <li><a href="#" data-md="compiler/index.md">Overview</a></li>
                     </ul>
                 </li>
-                <li class="category"><span>Language Basics</span>
+                <li class="category"><span>Dream.dr Language</span>
                     <ul>
-                        <li><a href="#" data-md="variables.md">Variables</a></li>
-                        <li><a href="#" data-md="arithmetic.md">Arithmetic</a></li>
-                        <li><a href="#" data-md="parentheses.md">Parentheses</a></li>
-                        <li><a href="#" data-md="comparison.md">Comparison</a></li>
-                        <li><a href="#" data-md="logical.md">Logical Operators</a></li>
-                        <li><a href="#" data-md="conditional.md">Conditional Operator</a></li>
-                        <li><a href="#" data-md="console.md">Console Output</a></li>
-                        <li><a href="#" data-md="strings.md">String Literals</a></li>
-                        <li><a href="#" data-md="comments.md">Comments</a></li>
-                        <li><a href="#" data-md="functions.md">Functions</a></li>
-                        <li><a href="#" data-md="classes.md">Classes</a></li>
+                        <li><a href="#" data-md="language/index.md">Overview</a></li>
+                        <li class="category"><span>Getting Started</span>
+                            <ul>
+                                <li><a href="#" data-md="v1/intro.md">Introduction</a></li>
+                                <li><a href="#" data-md="v1/usage.md">Usage Guide</a></li>
+                            </ul>
+                        </li>
+                        <li class="category"><span>Language Basics</span>
+                            <ul>
+                                <li><a href="#" data-md="variables.md">Variables</a></li>
+                                <li><a href="#" data-md="arrays.md">Arrays</a></li>
+                                <li><a href="#" data-md="arithmetic.md">Arithmetic</a></li>
+                                <li><a href="#" data-md="parentheses.md">Parentheses</a></li>
+                                <li><a href="#" data-md="comparison.md">Comparison</a></li>
+                                <li><a href="#" data-md="logical.md">Logical Operators</a></li>
+                                <li><a href="#" data-md="conditional.md">Conditional Operator</a></li>
+                                <li><a href="#" data-md="console.md">Console Output</a></li>
+                                <li><a href="#" data-md="strings.md">String Literals</a></li>
+                                <li><a href="#" data-md="comments.md">Comments</a></li>
+                                <li><a href="#" data-md="functions.md">Functions</a></li>
+                                <li><a href="#" data-md="classes.md">Classes</a></li>
+                            </ul>
+                        </li>
+                        <li class="category"><span>Control Flow</span>
+                            <ul>
+                                <li><a href="#" data-md="if.md">If Statements</a></li>
+                                <li><a href="#" data-md="loops.md">Loops</a></li>
+                                <li><a href="#" data-md="switch.md">Switch Statements</a></li>
+                                <li><a href="#" data-md="return.md">Return</a></li>
+                            </ul>
+                        </li>
+                        <li class="category"><span>Other</span>
+                            <ul>
+                                <li><a href="#" data-md="changelog.md">Changelog</a></li>
+                                <li><a href="#" data-md="architecture.md">Source Architecture</a></li>
+                                <li><a href="#" data-md="grammar/Grammar.md">Grammar Spec</a></li>
+                            </ul>
+                        </li>
                     </ul>
                 </li>
-                <li class="category"><span>Control Flow</span>
-                    <ul>
-                        <li><a href="#" data-md="if.md">If Statements</a></li>
-                        <li><a href="#" data-md="loops.md">Loops</a></li>
-                        <li><a href="#" data-md="switch.md">Switch Statements</a></li>
-                        <li><a href="#" data-md="return.md">Return</a></li>
-                    </ul>
-                </li>
-                <li><a href="#" data-md="changelog.md">Changelog</a></li>
-                <li><a href="#" data-md="architecture.md">Source Architecture</a></li>
             </ul>
         </nav>
     </aside>
@@ -67,9 +80,7 @@
         const navLinks = document.querySelectorAll('.nav a');
         const themeToggle = document.getElementById('theme-toggle');
         const themeLink = document.querySelector('link[rel="stylesheet"]');
-        const versionSelect = document.getElementById('version-select');
         const categories = document.querySelectorAll('.category');
-        let currentVersion = versionSelect.value;
 
         // Apply saved theme
         if (localStorage.getItem('theme') === 'dark') {
@@ -90,8 +101,7 @@
         }
 
         function resolvePath(mdFile) {
-            if (mdFile.includes('/')) return mdFile;
-            return `${currentVersion}/${mdFile}`;
+            return mdFile;
         }
 
         // Handle nav link clicks
@@ -114,13 +124,7 @@
             });
         });
 
-        versionSelect.addEventListener('change', () => {
-            currentVersion = versionSelect.value;
-            const active = document.querySelector('.nav a.active');
-            if (active && active.dataset.md !== 'changelog.md') {
-                loadMarkdown(resolvePath(active.dataset.md));
-            }
-        });
+
 
         // Toggle light/dark mode
         themeToggle.addEventListener('click', () => {
@@ -136,16 +140,11 @@
             }
         });
 
-        // Load default page (intro.md by default)
-        const defaultLink = document.querySelector('.nav a[data-md="intro.md"]');
+        // Load default page
+        const defaultLink = document.querySelector('.nav a[data-md="index.md"]');
         if (defaultLink) {
             defaultLink.classList.add('active');
-            loadMarkdown(resolvePath('intro.md'));
-            // Open the "Getting Started" category by default
-            const gettingStarted = document.querySelector('.category:first-child');
-            if (gettingStarted) {
-                gettingStarted.classList.add('open');
-            }
+            loadMarkdown(resolvePath('index.md'));
         }
     });
 </script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,39 +1,8 @@
-# Dream Compiler Documentation
+# Dream Documentation
 
-Welcome to the documentation for the Dream language and compiler. Many of the sections below describe planned features that are **not yet implemented**. The referenced guides are placeholders until the compiler gains support for them.
+Welcome to the Dream project. This site is split into two main sections:
 
-## Guides
+- **[Compiler Docs](compiler/index.md)** – build instructions, architecture notes and developer guides.
+- **[Dream.dr Language](language/index.md)** – syntax overview, examples and standard library information. See that page for a detailed table of contents.
 
-Use the version dropdown in the sidebar to view documentation for other releases.
-
-### Getting Started
-
-- [Introduction](v1/intro.md)
-- [Usage Guide](v1/usage.md)
-
-### Language Basics (planned)
-
- - Variables
-- Arrays *(pending)*
-- Arithmetic *(pending)*
-- Parentheses *(pending)*
-- Comparison *(pending)*
-- Logical Operators *(pending)*
-- Conditional Operator *(pending)*
-- Console Output *(pending)*
-- String Literals *(pending)*
-- Comments *(pending)*
- - Functions
-- Classes *(pending)*
-
-### Control Flow (planned)
-
-- If Statements *(pending)*
-- Loops *(pending)*
-- Switch Statements *(pending)*
-- Return *(pending)*
-
-### Other
-
-- Changelog
-- Source Architecture
+See the [Changelog](changelog.md) for recent updates.

--- a/docs/language/index.md
+++ b/docs/language/index.md
@@ -1,0 +1,37 @@
+# Dream.dr Language
+
+Here you will find the syntax guide, examples and references for the Dream.dr programming language.
+
+### Getting Started
+
+- [Introduction](../v1/intro.md)
+- [Usage Guide](../v1/usage.md)
+
+### Language Basics *(planned)*
+
+- [Variables](../variables.md)
+- [Arrays](../arrays.md)
+- [Arithmetic](../arithmetic.md)
+- [Parentheses](../parentheses.md)
+- [Comparison](../comparison.md)
+- [Logical Operators](../logical.md)
+- [Conditional Operator](../conditional.md)
+- [Console Output](../console.md)
+- [String Literals](../strings.md)
+- [Comments](../comments.md)
+- [Functions](../functions.md)
+- [Classes](../classes.md)
+
+### Control Flow *(planned)*
+
+- [If Statements](../if.md)
+- [Loops](../loops.md)
+- [Switch Statements](../switch.md)
+- [Return](../return.md)
+
+### Other
+
+- [Changelog](../changelog.md)
+- [Source Architecture](../architecture.md)
+- [Grammar Specification](../grammar/Grammar.md)
+

--- a/docs/logical.md
+++ b/docs/logical.md
@@ -1,0 +1,4 @@
+# Logical Operators *(planned)*
+
+Support for `&&`, `||` and `!` is planned for conditional expressions and control flow.
+

--- a/docs/loops.md
+++ b/docs/loops.md
@@ -1,0 +1,4 @@
+# Loops *(planned)*
+
+`while`, `do` and `for` loops are planned. Example syntax will be provided once implemented.
+

--- a/docs/parentheses.md
+++ b/docs/parentheses.md
@@ -1,0 +1,4 @@
+# Parentheses *(planned)*
+
+Parentheses will be used to group sub-expressions and override precedence. This feature is on the roadmap.
+

--- a/docs/return.md
+++ b/docs/return.md
@@ -1,0 +1,4 @@
+# Return *(planned)*
+
+The `return` statement will exit a function and optionally yield a value. Current planning stages are under way.
+

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -1,0 +1,4 @@
+# String Literals *(planned)*
+
+String handling is not fully fleshed out. This page will document escape sequences and concatenation when implemented.
+

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -1,0 +1,4 @@
+# Switch Statements *(planned)*
+
+A `switch` construct will allow branching on integer values. It is not yet available.
+

--- a/docs/v1/intro.md
+++ b/docs/v1/intro.md
@@ -1,0 +1,4 @@
+# Introduction
+
+Dream.dr is a small experimental language with C#-like syntax. The Dream compiler translates `.dr` files into portable C code built with Zig. These docs cover the language features that exist today and outline planned additions.
+

--- a/docs/v1/usage.md
+++ b/docs/v1/usage.md
@@ -1,0 +1,10 @@
+# Usage Guide
+
+Compile a program by running:
+
+```bash
+zig build run -- path/to/file.dr
+```
+
+This produces `dream.c` and an executable called `dream`. The examples throughout these docs assume basic familiarity with a command line.
+

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,0 +1,12 @@
+# Variables
+
+Dream.dr supports `int`, `bool` and `string` variables. Declarations use C-style syntax:
+
+```dream
+int x = 1;
+bool flag;
+string message = "hi";
+```
+
+Multiple variables may be declared in one statement separated by commas.
+


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added back documentation pages for all language topics with brief explanations. Updated `index.html` navigation to include the full language table of contents under the "Dream.dr Language" channel. Updated `language/index.md` and `index.md` accordingly. Updated README links and noted the changes in `docs/changelog.md`.

Related Files
Modified: `README.md`
Modified: `docs/index.html`
Modified: `docs/index.md`
Modified: `docs/language/index.md`
Modified: `docs/changelog.md`
Added: `docs/v1/intro.md`
Added: `docs/v1/usage.md`
Added: `docs/variables.md`
Added: `docs/arithmetic.md`
Added: `docs/arrays.md`
Added: `docs/parentheses.md`
Added: `docs/comparison.md`
Added: `docs/logical.md`
Added: `docs/conditional.md`
Added: `docs/console.md`
Added: `docs/strings.md`
Added: `docs/comments.md`
Added: `docs/classes.md`
Added: `docs/if.md`
Added: `docs/loops.md`
Added: `docs/switch.md`
Added: `docs/return.md`
Added: `docs/architecture.md`

Changes
Reintroduced the full set of language documentation files and reorganized the documentation navigation. The new language index lists each topic, and index.html loads them via the sidebar. README now points to both compiler docs and language docs. Changelog entry added.

Testing
- `zig build` (no output)
- `zig build test` (no output)
- `make test` (failed: no rule to make target 'test')

Dependencies
None.

Documentation
Added and updated numerous files under `docs/` as listed.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `zig build run` (none present)
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
N/A

------
https://chatgpt.com/codex/tasks/task_e_68797ad73b54832b9c610ef4ae95f088