### PR TITLE
[dreamc] update lexer plugin generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,17 @@ Dream Compiler is released under the [MIT License](LICENSE).
 
 ## Syntax Highlighting
 
-Generate the VS Code grammar from `tokens.json` at the repository root. The generator
-also syncs copies under `idea/` used by the JetBrains plugin:
+Generate the VS Code grammar from `src/lexer/tokens.def`. The generator
+also syncs copies under `assets/jetbrains` used by the JetBrains plugin:
 
 ```bash
-node scripts/genFromTokens.js
+node assets/jetbrains/scripts/genFromTokens.js
 ```
 
 ### VS Code
 
 ```bash
-cd vscode
+cd assets/vscode
 npm install
 npx vsce package
 ```
@@ -90,10 +90,10 @@ npx vsce package
 ### JetBrains Plugin
 
 ```bash
-cd idea
+cd assets/jetbrains
 ./gradlew generateLexer build test
 ```
-Ensure a JDK 17 is available. The build regenerates the lexer from `tokens.json` before compiling and running the tests.
+Ensure a JDK 17 is available. The build regenerates the lexer from `tokens.def` before compiling and running the tests.
 
 The resulting VSIX and plugin zip live in their respective directories.
 

--- a/assets/jetbrains/build.gradle.kts
+++ b/assets/jetbrains/build.gradle.kts
@@ -39,7 +39,7 @@ tasks {
 
     val generateTokens by registering(Exec::class) {
         workingDir = projectDir.parentFile
-        commandLine("node", "scripts/genFromTokens.js")
+        commandLine("node", "jetbrains/scripts/genFromTokens.js")
     }
 
     patchPluginXml {

--- a/assets/vscode/syntaxes/dream.tmLanguage.json
+++ b/assets/vscode/syntaxes/dream.tmLanguage.json
@@ -11,19 +11,15 @@
       "patterns": [
         {
           "name": "keyword.control",
-          "match": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|true|false|func|Console|WriteLine|Write|switch|case|default)\\b"
+          "match": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\\b"
         },
         {
           "name": "constant.numeric",
-          "match": "\\b\\d+(\\.\\d+)?\\b"
+          "match": "\\b(?:[0-9]+\\\\.[0-9]+|[0-9]+)\\b"
         },
         {
           "name": "string.quoted.double",
-          "match": "\"([^\\\"\\n]|\\\\.)*\""
-        },
-        {
-          "name": "string.quoted.single",
-          "match": "'([^'\\n]|\\\\.)'"
+          "match": "\\\"([^\\\\\\\"\\\\n]|\\\\\\\\.)*\\\""
         },
         {
           "name": "comment.block.documentation",
@@ -39,11 +35,11 @@
         },
         {
           "name": "variable.other",
-          "match": "\b[a-zA-Z_][a-zA-Z0-9_]*\b"
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
         },
         {
           "name": "keyword.operator",
-          "match": "\\+\\+|--|\\+=|-=|\\*=|/=|%=|\\+|-|\\*|\\/|%|\\^|<<|>>|<=|>=|==|!=|<|>|&&|\\|\\||&|\\||!|~|=|\\?"
+          "match": "\\\\+\\\\+|--|\\\\+=|-=|\\\\*=|/=|%=|&=|\\\\|=|\\\\^=|<<=|>>=|\\\\+|-|\\\\*|/|%|\\\\^|<<|>>|<=|>=|==|!=|<|>|&&|\\\\|\\\\||&|\\\\||~|!|=|\\\\?|\\\\?\\\\?|\\\\?\\\\?="
         },
         {
           "name": "punctuation.terminator.statement",
@@ -55,7 +51,7 @@
         },
         {
           "name": "punctuation.accessor",
-          "match": "\\."
+          "match": "\\\\."
         },
         {
           "name": "punctuation.section.parens",


### PR DESCRIPTION
## What changed
- read `src/lexer/tokens.def` from the generator script and build highlighting tokens from it
- updated README and Gradle build to use the new script path and token source
- regenerated VS Code grammar with the new keywords

## How it was tested
- `zig fmt --check`
- `zig build`
- `node assets/jetbrains/scripts/genFromTokens.js`

## Docs updated
- `README.md` syntax highlighting instructions

## Dependencies
- none

------
https://chatgpt.com/codex/tasks/task_e_687985108b08832b9b9947eebb347961