### PR TITLE
[dreamc] restore JetBrains plugin sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@
 # Build artifacts
 /build
 dream
+!assets/jetbrains/src/main/java/com/dream
+!assets/jetbrains/src/main/kotlin/com/dream
 output.c
 
 # Zig

--- a/assets/jetbrains/scripts/genFromTokens.js
+++ b/assets/jetbrains/scripts/genFromTokens.js
@@ -48,7 +48,8 @@ const opRegex = operatorNames
 
 const tokens = [
   { name: 'keyword', regex: `\\b(${kwRegex})\\b`, scope: 'keyword.control' },
-  { name: 'number', regex: `\\b(?:${defs.FLOAT_LITERAL}|${defs.INT_LITERAL})\\b`, scope: 'constant.numeric' },
+  // JFlex does not support non-capturing groups, so use a normal group instead
+  { name: 'number', regex: `\\b(${defs.FLOAT_LITERAL}|${defs.INT_LITERAL})\\b`, scope: 'constant.numeric' },
   { name: 'string', regex: defs.STRING_LITERAL, scope: 'string.quoted.double' },
   { name: 'commentDoc', regex: '/\\*\\*[^]*?\\*/|///.*', scope: 'comment.block.documentation' },
   { name: 'comment', regex: '//.*', scope: 'comment.line.double-slash' },

--- a/assets/jetbrains/src/main/java/com/dream/DreamCodeStyleSettings.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamCodeStyleSettings.java
@@ -1,0 +1,10 @@
+package com.dream;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+
+public class DreamCodeStyleSettings extends CustomCodeStyleSettings {
+    protected DreamCodeStyleSettings(CodeStyleSettings settings) {
+        super("DreamCodeStyleSettings", settings);
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamCodeStyleSettingsProvider.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamCodeStyleSettingsProvider.java
@@ -1,0 +1,39 @@
+package com.dream;
+
+import com.intellij.application.options.CodeStyleAbstractConfigurable;
+import com.intellij.application.options.CodeStyleAbstractPanel;
+import com.intellij.application.options.TabbedLanguageCodeStylePanel;
+import com.intellij.psi.codeStyle.CodeStyleConfigurable;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+import org.jetbrains.annotations.NotNull;
+
+public class DreamCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
+    @Override
+    public CustomCodeStyleSettings createCustomSettings(@NotNull CodeStyleSettings settings) {
+        return new DreamCodeStyleSettings(settings);
+    }
+
+    @Override
+    public String getConfigurableDisplayName() {
+        return "Dream";
+    }
+
+    @Override
+    public @NotNull CodeStyleConfigurable createConfigurable(@NotNull CodeStyleSettings settings,
+                                                             @NotNull CodeStyleSettings modelSettings) {
+        return new CodeStyleAbstractConfigurable(settings, modelSettings, getConfigurableDisplayName()) {
+            @Override
+            protected @NotNull CodeStyleAbstractPanel createPanel(@NotNull CodeStyleSettings settings) {
+                return new DreamCodeStyleMainPanel(getCurrentSettings(), settings);
+            }
+        };
+    }
+
+    private static class DreamCodeStyleMainPanel extends TabbedLanguageCodeStylePanel {
+        protected DreamCodeStyleMainPanel(CodeStyleSettings currentSettings, CodeStyleSettings settings) {
+            super(DreamLanguage.INSTANCE, currentSettings, settings);
+        }
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamColorSettingsPage.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamColorSettingsPage.java
@@ -1,0 +1,84 @@
+package com.dream;
+
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.openapi.options.colors.AttributesDescriptor;
+import com.intellij.openapi.options.colors.ColorDescriptor;
+import com.intellij.openapi.options.colors.ColorSettingsPage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Map;
+
+public class DreamColorSettingsPage implements ColorSettingsPage {
+    private static final AttributesDescriptor[] DESCRIPTORS = new AttributesDescriptor[]{
+            new AttributesDescriptor("Keyword", DreamSyntaxHighlighter.KEYWORD),
+            new AttributesDescriptor("Number", DreamSyntaxHighlighter.NUMBER),
+            new AttributesDescriptor("String", DreamSyntaxHighlighter.STRING),
+            new AttributesDescriptor("Comment", DreamSyntaxHighlighter.COMMENT),
+            new AttributesDescriptor("Operator", DreamSyntaxHighlighter.OPERATOR),
+            new AttributesDescriptor("Semicolon", DreamSyntaxHighlighter.SEMICOLON),
+            new AttributesDescriptor("Comma", DreamSyntaxHighlighter.COMMA),
+            new AttributesDescriptor("Dot", DreamSyntaxHighlighter.DOT),
+            new AttributesDescriptor("Parentheses", DreamSyntaxHighlighter.PAREN),
+            new AttributesDescriptor("Braces", DreamSyntaxHighlighter.BRACE),
+            new AttributesDescriptor("Brackets", DreamSyntaxHighlighter.BRACKET)
+    };
+
+    @Override
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Override
+    public SyntaxHighlighter getHighlighter() {
+        return new DreamSyntaxHighlighter();
+    }
+
+    @NotNull
+    @Override
+    public String getDemoText() {
+        return """
+// This is a single-line comment.
+/*
+  This is a
+  multi-line block comment.
+*/
+func calculateSum(a, b) {
+    // Using keywords, numbers, and operators
+    let result = a + b;
+    let pi = 3.14;
+    let arr = [1, 2, 3];
+    let message = "The result is: ";
+    Console.WriteLine(message + arr[0] + result);
+    return result;
+}
+
+// Calling the function with parentheses and a semicolon
+let sum = calculateSum(10, 20);
+""";
+    }
+
+    @Nullable
+    @Override
+    public Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap() {
+        return null;
+    }
+
+    @Override
+    public AttributesDescriptor[] getAttributeDescriptors() {
+        return DESCRIPTORS;
+    }
+
+    @Override
+    public ColorDescriptor[] getColorDescriptors() {
+        return ColorDescriptor.EMPTY_ARRAY;
+    }
+
+    @NotNull
+    @Override
+    public String getDisplayName() {
+        return "Dream";
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamElementType.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamElementType.java
@@ -1,0 +1,11 @@
+package com.dream;
+
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public class DreamElementType extends IElementType {
+    public DreamElementType(@NotNull @NonNls String debugName) {
+        super(debugName, DreamLanguage.INSTANCE);
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamLanguageCodeStyleSettingsProvider.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamLanguageCodeStyleSettingsProvider.java
@@ -1,0 +1,27 @@
+package com.dream;
+
+import com.intellij.lang.Language;
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable;
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider;
+import org.jetbrains.annotations.NotNull;
+
+public class DreamLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSettingsProvider {
+    @NotNull
+    @Override
+    public Language getLanguage() {
+        return DreamLanguage.INSTANCE;
+    }
+
+    @Override
+    public void customizeSettings(@NotNull CodeStyleSettingsCustomizable consumer, @NotNull SettingsType settingsType) {
+        if (settingsType == SettingsType.INDENT_SETTINGS) {
+            consumer.showStandardOptions("INDENT_SIZE", "TAB_SIZE", "USE_TAB_CHARACTER");
+        }
+    }
+
+    @NotNull
+    @Override
+    public String getCodeSample(@NotNull SettingsType settingsType) {
+        return "int x = 5;\nif (x > 0) {\n    Console.WriteLine(x);\n}";
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamLexerAdapter.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamLexerAdapter.java
@@ -1,0 +1,9 @@
+package com.dream;
+
+import com.intellij.lexer.FlexAdapter;
+
+public class DreamLexerAdapter extends FlexAdapter {
+    public DreamLexerAdapter() {
+        super(new DreamLexer(null));
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamSyntaxHighlighter.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamSyntaxHighlighter.java
@@ -1,0 +1,63 @@
+package com.dream;
+
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
+import com.intellij.lexer.Lexer;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.openapi.fileTypes.SyntaxHighlighterBase;
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NotNull;
+
+
+public class DreamSyntaxHighlighter extends SyntaxHighlighterBase {
+    private final Lexer lexer = new DreamLexerAdapter();
+
+    @NotNull
+    @Override
+    public Lexer getHighlightingLexer() {
+        return lexer;
+    }
+
+    public static final TextAttributesKey KEYWORD = TextAttributesKey.createTextAttributesKey("DREAM_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
+    public static final TextAttributesKey NUMBER = TextAttributesKey.createTextAttributesKey("DREAM_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
+    public static final TextAttributesKey STRING = TextAttributesKey.createTextAttributesKey("DREAM_STRING", DefaultLanguageHighlighterColors.STRING);
+    public static final TextAttributesKey COMMENT = TextAttributesKey.createTextAttributesKey("DREAM_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
+    public static final TextAttributesKey OPERATOR = TextAttributesKey.createTextAttributesKey("DREAM_OPERATOR", DefaultLanguageHighlighterColors.OPERATION_SIGN);
+    public static final TextAttributesKey SEMICOLON = TextAttributesKey.createTextAttributesKey("DREAM_SEMICOLON", DefaultLanguageHighlighterColors.SEMICOLON);
+    public static final TextAttributesKey COMMA = TextAttributesKey.createTextAttributesKey("DREAM_COMMA", DefaultLanguageHighlighterColors.COMMA);
+    public static final TextAttributesKey DOT = TextAttributesKey.createTextAttributesKey("DREAM_DOT", DefaultLanguageHighlighterColors.DOT);
+    public static final TextAttributesKey PAREN = TextAttributesKey.createTextAttributesKey("DREAM_PAREN", DefaultLanguageHighlighterColors.PARENTHESES);
+    public static final TextAttributesKey BRACE = TextAttributesKey.createTextAttributesKey("DREAM_BRACE", DefaultLanguageHighlighterColors.BRACES);
+    public static final TextAttributesKey BRACKET = TextAttributesKey.createTextAttributesKey("DREAM_BRACKET", DefaultLanguageHighlighterColors.BRACKETS);
+
+    private static final TextAttributesKey[] KEYWORD_KEYS = new TextAttributesKey[]{KEYWORD};
+    private static final TextAttributesKey[] NUMBER_KEYS = new TextAttributesKey[]{NUMBER};
+    private static final TextAttributesKey[] STRING_KEYS = new TextAttributesKey[]{STRING};
+    private static final TextAttributesKey[] COMMENT_KEYS = new TextAttributesKey[]{COMMENT};
+    private static final TextAttributesKey[] OPERATOR_KEYS = new TextAttributesKey[]{OPERATOR};
+    private static final TextAttributesKey[] SEMICOLON_KEYS = new TextAttributesKey[]{SEMICOLON};
+    private static final TextAttributesKey[] COMMA_KEYS = new TextAttributesKey[]{COMMA};
+    private static final TextAttributesKey[] DOT_KEYS = new TextAttributesKey[]{DOT};
+    private static final TextAttributesKey[] PAREN_KEYS = new TextAttributesKey[]{PAREN};
+    private static final TextAttributesKey[] BRACE_KEYS = new TextAttributesKey[]{BRACE};
+    private static final TextAttributesKey[] BRACKET_KEYS = new TextAttributesKey[]{BRACKET};
+
+    @NotNull
+    @Override
+    public TextAttributesKey[] getTokenHighlights(IElementType tokenType) {
+        if (tokenType == DreamTokenTypes.KEYWORD) return KEYWORD_KEYS;
+        if (tokenType == DreamTokenTypes.NUMBER) return NUMBER_KEYS;
+        if (tokenType == DreamTokenTypes.STRING) return STRING_KEYS;
+        if (tokenType == DreamTokenTypes.COMMENT ||
+            tokenType == DreamTokenTypes.COMMENTBLOCK ||
+            tokenType == DreamTokenTypes.COMMENTDOC) return COMMENT_KEYS;
+        if (tokenType == DreamTokenTypes.OPERATOR) return OPERATOR_KEYS;
+        if (tokenType == DreamTokenTypes.SEMICOLON) return SEMICOLON_KEYS;
+        if (tokenType == DreamTokenTypes.COMMA) return COMMA_KEYS;
+        if (tokenType == DreamTokenTypes.DOT) return DOT_KEYS;
+        if (tokenType == DreamTokenTypes.PAREN) return PAREN_KEYS;
+        if (tokenType == DreamTokenTypes.BRACE) return BRACE_KEYS;
+        if (tokenType == DreamTokenTypes.BRACKET) return BRACKET_KEYS;
+        return TextAttributesKey.EMPTY_ARRAY;
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamSyntaxHighlighterFactory.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamSyntaxHighlighterFactory.java
@@ -1,0 +1,13 @@
+package com.dream;
+
+import com.intellij.openapi.fileTypes.SingleLazyInstanceSyntaxHighlighterFactory;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import org.jetbrains.annotations.NotNull;
+
+public class DreamSyntaxHighlighterFactory extends SingleLazyInstanceSyntaxHighlighterFactory {
+    @NotNull
+    @Override
+    protected SyntaxHighlighter createHighlighter() {
+        return new DreamSyntaxHighlighter();
+    }
+}

--- a/assets/jetbrains/src/main/java/com/dream/DreamTokenTypes.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamTokenTypes.java
@@ -1,0 +1,20 @@
+package com.dream;
+
+import com.intellij.psi.tree.IElementType;
+
+public interface DreamTokenTypes {
+    IElementType KEYWORD = new DreamElementType("KEYWORD");
+    IElementType NUMBER = new DreamElementType("NUMBER");
+    IElementType STRING = new DreamElementType("STRING");
+    IElementType COMMENT = new DreamElementType("COMMENT");
+    IElementType COMMENTBLOCK = new DreamElementType("COMMENTBLOCK");
+    IElementType OPERATOR = new DreamElementType("OPERATOR");
+    IElementType SEMICOLON = new DreamElementType("SEMICOLON");
+    IElementType COMMA = new DreamElementType("COMMA");
+    IElementType DOT = new DreamElementType("DOT");
+    IElementType PAREN = new DreamElementType("PAREN");
+    IElementType BRACE = new DreamElementType("BRACE");
+    IElementType IDENTIFIER = new DreamElementType("IDENTIFIER");
+    IElementType BRACKET = new DreamElementType("BRACKET");
+    IElementType COMMENTDOC = new DreamElementType("COMMENTDOC");
+}

--- a/assets/jetbrains/src/main/kotlin/com/dream/DreamFileType.kt
+++ b/assets/jetbrains/src/main/kotlin/com/dream/DreamFileType.kt
@@ -1,0 +1,12 @@
+package com.dream
+
+import com.intellij.openapi.fileTypes.LanguageFileType
+import icons.MyIcons
+import javax.swing.Icon
+
+object DreamFileType : LanguageFileType(DreamLanguage) {
+    override fun getName() = "Dream file"
+    override fun getDescription() = "Dream language file"
+    override fun getDefaultExtension() = "dr"
+    override fun getIcon(): Icon = MyIcons.FILE
+}

--- a/assets/jetbrains/src/main/kotlin/com/dream/DreamLanguage.kt
+++ b/assets/jetbrains/src/main/kotlin/com/dream/DreamLanguage.kt
@@ -1,0 +1,5 @@
+package com.dream
+
+import com.intellij.lang.Language
+
+object DreamLanguage : Language("dream")

--- a/assets/vscode/syntaxes/dream.tmLanguage.json
+++ b/assets/vscode/syntaxes/dream.tmLanguage.json
@@ -15,7 +15,7 @@
         },
         {
           "name": "constant.numeric",
-          "match": "\\b(?:[0-9]+\\\\.[0-9]+|[0-9]+)\\b"
+          "match": "\\b([0-9]+\\\\.[0-9]+|[0-9]+)\\b"
         },
         {
           "name": "string.quoted.double",


### PR DESCRIPTION
## Summary
- restore missing JetBrains plugin source files under `assets/jetbrains`
- allow plugin sources in gitignore so they are tracked

## Testing
- `zig build --verbose`
- `gradle buildPlugin`

------
https://chatgpt.com/codex/tasks/task_e_687992daba2c832bbc2f4ccb86f970d5