### PR TITLE
[dreamc] fix JetBrains keyword/number highlighting

### DIFF
--- a/assets/jetbrains/src/main/java/com/dream/DreamLexer.flex
+++ b/assets/jetbrains/src/main/java/com/dream/DreamLexer.flex
@@ -10,13 +10,13 @@ package com.dream;
 
 %%
 <YYINITIAL> {
-  \b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\b { return DreamTokenTypes.KEYWORD; }
-  \b([0-9]+\\.[0-9]+|[0-9]+)\b { return DreamTokenTypes.NUMBER; }
+  (if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)(?![A-Za-z0-9_]) { return DreamTokenTypes.KEYWORD; }
+  ([0-9]+\\.[0-9]+|[0-9]+)(?![A-Za-z0-9_]) { return DreamTokenTypes.NUMBER; }
   \"([^\\\"\\n]|\\\\.)*\" { return DreamTokenTypes.STRING; }
   "/\*\*[^]*?\\*\/|\/\//.*" { return DreamTokenTypes.COMMENTDOC; }
   \/\/.* { return DreamTokenTypes.COMMENT; }
   "/\*[\s\S]*?\\*\/" { return DreamTokenTypes.COMMENTBLOCK; }
-  \b[a-zA-Z_][a-zA-Z0-9_]*\b { return DreamTokenTypes.IDENTIFIER; }
+  [a-zA-Z_][a-zA-Z0-9_]*(?![A-Za-z0-9_]) { return DreamTokenTypes.IDENTIFIER; }
   "\\+\\+"|"--"|"\\+="|"-="|"\\*="|"/="|"%="|"&="|"\\|="|"\\^="|"<<="|">>="|"\\+"|"-"|"\\*"|"/"|"%"|"\\^"|"<<"|">>"|"<="|">="|"=="|"!="|"<"|">"|"&&"|"\\|\\|"|"&"|"\\|"|"~"|"!"|"="|"\\?"|"\\?\\?"|"\\?\\?=" { return DreamTokenTypes.OPERATOR; }
   ; { return DreamTokenTypes.SEMICOLON; }
   , { return DreamTokenTypes.COMMA; }

--- a/assets/jetbrains/src/main/resources/tokens.json
+++ b/assets/jetbrains/src/main/resources/tokens.json
@@ -2,11 +2,13 @@
   {
     "name": "keyword",
     "regex": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\\b",
+    "flex": "(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)(?![A-Za-z0-9_])",
     "scope": "keyword.control"
   },
   {
     "name": "number",
     "regex": "\\b([0-9]+\\\\.[0-9]+|[0-9]+)\\b",
+    "flex": "([0-9]+\\\\.[0-9]+|[0-9]+)(?![A-Za-z0-9_])",
     "scope": "constant.numeric"
   },
   {
@@ -32,6 +34,7 @@
   {
     "name": "identifier",
     "regex": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
+    "flex": "[a-zA-Z_][a-zA-Z0-9_]*(?![A-Za-z0-9_])",
     "scope": "variable.other"
   },
   {

--- a/assets/jetbrains/tokens.json
+++ b/assets/jetbrains/tokens.json
@@ -2,11 +2,13 @@
   {
     "name": "keyword",
     "regex": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\\b",
+    "flex": "(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)(?![A-Za-z0-9_])",
     "scope": "keyword.control"
   },
   {
     "name": "number",
     "regex": "\\b([0-9]+\\\\.[0-9]+|[0-9]+)\\b",
+    "flex": "([0-9]+\\\\.[0-9]+|[0-9]+)(?![A-Za-z0-9_])",
     "scope": "constant.numeric"
   },
   {
@@ -32,6 +34,7 @@
   {
     "name": "identifier",
     "regex": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
+    "flex": "[a-zA-Z_][a-zA-Z0-9_]*(?![A-Za-z0-9_])",
     "scope": "variable.other"
   },
   {


### PR DESCRIPTION
## Summary
- ensure word boundaries work in the JetBrains lexer
- regenerate the tokens JSON and lexer spec

## Testing
- `zig fmt --check $(git ls-files '*.zig')`
- `zig build`
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68799ea761d4832bb08271fbac32ddad