### PR TITLE
[dreamc] fix plugin lexer word boundaries

### DIFF
--- a/assets/jetbrains/src/main/java/com/dream/DreamLexer.flex
+++ b/assets/jetbrains/src/main/java/com/dream/DreamLexer.flex
@@ -10,13 +10,13 @@ package com.dream;
 
 %%
 <YYINITIAL> {
-  (if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)(?![A-Za-z0-9_]) { return DreamTokenTypes.KEYWORD; }
-  ([0-9]+\\.[0-9]+|[0-9]+)(?![A-Za-z0-9_]) { return DreamTokenTypes.NUMBER; }
+  \b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\b { return DreamTokenTypes.KEYWORD; }
+  \b([0-9]+\\.[0-9]+|[0-9]+)\b { return DreamTokenTypes.NUMBER; }
   \"([^\\\"\\n]|\\\\.)*\" { return DreamTokenTypes.STRING; }
   "/\*\*[^]*?\\*\/|\/\//.*" { return DreamTokenTypes.COMMENTDOC; }
   \/\/.* { return DreamTokenTypes.COMMENT; }
   "/\*[\s\S]*?\\*\/" { return DreamTokenTypes.COMMENTBLOCK; }
-  [a-zA-Z_][a-zA-Z0-9_]*(?![A-Za-z0-9_]) { return DreamTokenTypes.IDENTIFIER; }
+  \b[a-zA-Z_][a-zA-Z0-9_]*\b { return DreamTokenTypes.IDENTIFIER; }
   "\\+\\+"|"--"|"\\+="|"-="|"\\*="|"/="|"%="|"&="|"\\|="|"\\^="|"<<="|">>="|"\\+"|"-"|"\\*"|"/"|"%"|"\\^"|"<<"|">>"|"<="|">="|"=="|"!="|"<"|">"|"&&"|"\\|\\|"|"&"|"\\|"|"~"|"!"|"="|"\\?"|"\\?\\?"|"\\?\\?=" { return DreamTokenTypes.OPERATOR; }
   ; { return DreamTokenTypes.SEMICOLON; }
   , { return DreamTokenTypes.COMMA; }

--- a/assets/jetbrains/src/main/resources/tokens.json
+++ b/assets/jetbrains/src/main/resources/tokens.json
@@ -2,13 +2,13 @@
   {
     "name": "keyword",
     "regex": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\\b",
-    "flex": "(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)(?![A-Za-z0-9_])",
+    "flex": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\\b",
     "scope": "keyword.control"
   },
   {
     "name": "number",
     "regex": "\\b([0-9]+\\\\.[0-9]+|[0-9]+)\\b",
-    "flex": "([0-9]+\\\\.[0-9]+|[0-9]+)(?![A-Za-z0-9_])",
+    "flex": "\\b([0-9]+\\\\.[0-9]+|[0-9]+)\\b",
     "scope": "constant.numeric"
   },
   {
@@ -34,7 +34,7 @@
   {
     "name": "identifier",
     "regex": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
-    "flex": "[a-zA-Z_][a-zA-Z0-9_]*(?![A-Za-z0-9_])",
+    "flex": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
     "scope": "variable.other"
   },
   {

--- a/assets/jetbrains/tokens.json
+++ b/assets/jetbrains/tokens.json
@@ -2,13 +2,13 @@
   {
     "name": "keyword",
     "regex": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\\b",
-    "flex": "(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)(?![A-Za-z0-9_])",
+    "flex": "\\b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\\b",
     "scope": "keyword.control"
   },
   {
     "name": "number",
     "regex": "\\b([0-9]+\\\\.[0-9]+|[0-9]+)\\b",
-    "flex": "([0-9]+\\\\.[0-9]+|[0-9]+)(?![A-Za-z0-9_])",
+    "flex": "\\b([0-9]+\\\\.[0-9]+|[0-9]+)\\b",
     "scope": "constant.numeric"
   },
   {
@@ -34,7 +34,7 @@
   {
     "name": "identifier",
     "regex": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
-    "flex": "[a-zA-Z_][a-zA-Z0-9_]*(?![A-Za-z0-9_])",
+    "flex": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b",
     "scope": "variable.other"
   },
   {


### PR DESCRIPTION
## Summary
- avoid unsupported negative lookahead in JetBrains lexer
- properly unescape token definitions
- regenerate lexer and token files

## Testing
- `zig fmt --check $(git ls-files '*.zig')`
- `zig build`
- `zig build test`
- `gradle buildPlugin --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6879b4ce2948832b9837dd2828824239