### PR TITLE
[dreamc] Document failing test cases

### DIFF
--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -5,3 +5,72 @@ The following feature still requires implementation:
 - Classes, structs and object creation
 
 Keep the grammar and documentation up to date once these features land.
+
+## Failing tests
+
+- tests/advanced/concurrency/async.dr
+- tests/advanced/concurrency/await.dr
+- tests/advanced/control_flow/switchcase.dr
+- tests/advanced/data_structures/array.dr
+- tests/advanced/data_structures/bool_array.dr
+- tests/advanced/data_structures/char_array.dr
+- tests/advanced/data_structures/float_array.dr
+- tests/advanced/data_structures/string_array.dr
+- tests/advanced/data_structures/struct.dr
+- tests/advanced/oop/class.dr
+- tests/advanced/oop/object.dr
+- tests/advanced/oop/type.dr
+- tests/basics/arithmetic/arithmetic.dr
+- tests/basics/arithmetic/compound_assign.dr
+- tests/basics/arithmetic/division.dr
+- tests/basics/arithmetic/modulo.dr
+- tests/basics/arithmetic/multiplication.dr
+- tests/basics/arithmetic/negative_numbers.dr
+- tests/basics/arithmetic/subtraction.dr
+- tests/basics/arithmetic/unary_plus.dr
+- tests/basics/bitwise/bitnot.dr
+- tests/basics/bitwise/bitwise_and_or.dr
+- tests/basics/bitwise/shift.dr
+- tests/basics/bitwise/xor.dr
+- tests/basics/comments/block_comment.dr
+- tests/basics/expressions/grouping_precedence.dr
+- tests/basics/expressions/mixed_precedence.dr
+- tests/basics/expressions/parentheses.dr
+- tests/basics/expressions/power_assoc.dr
+- tests/basics/expressions/ternary.dr
+- tests/basics/io/console.dr
+- tests/basics/io/readline.dr
+- tests/basics/io/write.dr
+- tests/basics/misc/bool_expr_output.dr
+- tests/basics/strings/string_concat.dr
+- tests/basics/strings/string_escape.dr
+- tests/basics/strings/string_output.dr
+- tests/basics/strings/string_var.dr
+- tests/basics/types/bool.dr
+- tests/basics/types/char.dr
+- tests/basics/types/float.dr
+- tests/basics/variables/multi_decl.dr
+- tests/basics/variables/var_infer.dr
+- tests/basics/variables/variables.dr
+- tests/control_flow/comparisons/comparison.dr
+- tests/control_flow/comparisons/equality.dr
+- tests/control_flow/comparisons/inequality.dr
+- tests/control_flow/conditionals/else_if.dr
+- tests/control_flow/conditionals/if.dr
+- tests/control_flow/conditionals/if_block.dr
+- tests/control_flow/conditionals/if_else.dr
+- tests/control_flow/increment/increment.dr
+- tests/control_flow/increment/increment_expression.dr
+- tests/control_flow/logical/logical.dr
+- tests/control_flow/logical/logical_not.dr
+- tests/control_flow/loops/break.dr
+- tests/control_flow/loops/break_continue.dr
+- tests/control_flow/loops/do_while.dr
+- tests/control_flow/loops/for.dr
+- tests/control_flow/loops/while.dr
+- tests/control_flow/loops/while_block.dr
+- tests/control_flow/switches/switch.dr
+- tests/functions/definitions/functions.dr
+- tests/functions/definitions/typed_return.dr
+- tests/functions/parameters/function_params.dr
+- tests/functions/returns/return.dr


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Ran `zig build` and executed each `.dr` file under `tests/` using the newly built compiler. Every test failed to compile. The failing test paths are now recorded in `tasks/TODO.md`.

Related Files
Modified: `tasks/TODO.md`

Changes
Added a new section listing all failing test files so they can be addressed.

Testing
```bash
zig build
for f in $(find tests -name '*.dr'); do ./zig-out/bin/DreamCompiler "$f"; done
```

Dependencies
None

Documentation
Updated TODO list. No other docs changed.

Checklist
- [ ] `zig build` succeeds
- [ ] All test files under `tests/` compile using `zig build run`
- [ ] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
All 66 tests currently fail. A sample error output:
```
1 warning and 7 errors generated.
failed to run: zig cc build/bin/dream.c -o dream
```

------
https://chatgpt.com/codex/tasks/task_e_6879bce2c870832ba3d508b81905b71f