### PR TITLE
[dreamc] fix type token check and char test

### DIFF
--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -122,7 +122,6 @@ static bool is_type_token(TokenKind k) {
   case TK_KW_CHAR:
   case TK_KW_STRING:
   case TK_KW_VAR:
-  case TK_IDENT:
   case TK_KW_STRUCT:
   case TK_KW_CLASS:
     return true;

--- a/tests/basics/types/char.dr
+++ b/tests/basics/types/char.dr
@@ -1,2 +1,2 @@
 char c = 'A';
-Console.WriteLine(c); // Expected: 65
+Console.WriteLine(c); // Expected: A


### PR DESCRIPTION
## What changed
- fixed `is_type_token` in the parser so identifiers aren't treated as types
- updated the char printing test to expect the character output

## How it was tested
- `zig build`
- `python/test_runner`


------
https://chatgpt.com/codex/tasks/task_e_6879d7d9c4b4832bb3bc73e73c5a69ae