### PR TITLE
[dreamc] Improve Dream plugin highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 dream
 !assets/jetbrains/src/main/java/com/dream
 !assets/jetbrains/src/main/kotlin/com/dream
+!assets/jetbrains/src/test/kotlin/com/dream
 output.c
 
 # Zig

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ npx vsce package
 
 ```bash
 cd assets/jetbrains
-./gradlew generateLexer build test
+gradle generateLexer build test
 ```
-Ensure a JDK 17 is available. The build regenerates the lexer from `tokens.def` before compiling and running the tests.
+Ensure `node` is on your `PATH` so `scripts/genFromTokens.js` can rebuild the lexer from `src/lexer/tokens.def` before compiling and running the tests.
 
 The resulting VSIX and plugin zip live in their respective directories.
 

--- a/assets/jetbrains/build.gradle.kts
+++ b/assets/jetbrains/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.gradle.api.JavaVersion
 
 plugins {
     id("java")
@@ -16,7 +17,8 @@ dependencies {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/assets/jetbrains/scripts/genFromTokens.js
+++ b/assets/jetbrains/scripts/genFromTokens.js
@@ -65,9 +65,9 @@ const tokens = [
     scope: 'constant.numeric',
   },
   { name: 'string', regex: defs.STRING_LITERAL, scope: 'string.quoted.double' },
-  { name: 'commentDoc', regex: '/\\*\\*[^]*?\\*/|///.*', scope: 'comment.block.documentation' },
-  { name: 'comment', regex: '//.*', scope: 'comment.line.double-slash' },
-  { name: 'commentBlock', regex: '/\\*[\\s\\S]*?\\*/', scope: 'comment.block' },
+  { name: 'doc_comment', regex: '/\\*\\*[^]*?\\*/|///.*', scope: 'comment.block.documentation' },
+  { name: 'line_comment', regex: '//.*', scope: 'comment.line.double-slash' },
+  { name: 'block_comment', regex: '/\\*[\\s\\S]*?\\*/', scope: 'comment.block' },
   {
     name: 'identifier',
     regex: `\\b${defs.IDENT}\\b`,

--- a/assets/jetbrains/src/main/java/com/dream/DreamLexer.flex
+++ b/assets/jetbrains/src/main/java/com/dream/DreamLexer.flex
@@ -13,9 +13,9 @@ package com.dream;
   \b(if|else|while|for|do|break|continue|return|class|struct|int|string|bool|float|char|void|var|true|false|func|switch|case|default|Console|WriteLine|Write|ReadLine)\b { return DreamTokenTypes.KEYWORD; }
   \b([0-9]+\\.[0-9]+|[0-9]+)\b { return DreamTokenTypes.NUMBER; }
   \"([^\\\"\\n]|\\\\.)*\" { return DreamTokenTypes.STRING; }
-  "/\*\*[^]*?\\*\/|\/\//.*" { return DreamTokenTypes.COMMENTDOC; }
-  \/\/.* { return DreamTokenTypes.COMMENT; }
-  "/\*[\s\S]*?\\*\/" { return DreamTokenTypes.COMMENTBLOCK; }
+  "/\*\*[^]*?\\*\/|\/\//.*" { return DreamTokenTypes.DOC_COMMENT; }
+  \/\/.* { return DreamTokenTypes.LINE_COMMENT; }
+  "/\*[\s\S]*?\\*\/" { return DreamTokenTypes.BLOCK_COMMENT; }
   \b[a-zA-Z_][a-zA-Z0-9_]*\b { return DreamTokenTypes.IDENTIFIER; }
   "\\+\\+"|"--"|"\\+="|"-="|"\\*="|"/="|"%="|"&="|"\\|="|"\\^="|"<<="|">>="|"\\+"|"-"|"\\*"|"/"|"%"|"\\^"|"<<"|">>"|"<="|">="|"=="|"!="|"<"|">"|"&&"|"\\|\\|"|"&"|"\\|"|"~"|"!"|"="|"\\?"|"\\?\\?"|"\\?\\?=" { return DreamTokenTypes.OPERATOR; }
   ; { return DreamTokenTypes.SEMICOLON; }

--- a/assets/jetbrains/src/main/java/com/dream/DreamLexer.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamLexer.java
@@ -681,7 +681,7 @@ public class DreamLexer implements com.intellij.lexer.FlexLexer {
           // fall through
           case 25: break;
           case 10:
-            { return DreamTokenTypes.COMMENT;
+            { return DreamTokenTypes.LINE_COMMENT;
             }
           // fall through
           case 26: break;
@@ -706,12 +706,12 @@ public class DreamLexer implements com.intellij.lexer.FlexLexer {
           // fall through
           case 30: break;
           case 15:
-            { return DreamTokenTypes.COMMENTBLOCK;
+            { return DreamTokenTypes.BLOCK_COMMENT;
             }
           // fall through
           case 31: break;
           case 16:
-            { return DreamTokenTypes.COMMENTDOC;
+            { return DreamTokenTypes.DOC_COMMENT;
             }
           // fall through
           case 32: break;

--- a/assets/jetbrains/src/main/java/com/dream/DreamSyntaxHighlighter.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamSyntaxHighlighter.java
@@ -48,9 +48,9 @@ public class DreamSyntaxHighlighter extends SyntaxHighlighterBase {
         if (tokenType == DreamTokenTypes.KEYWORD) return KEYWORD_KEYS;
         if (tokenType == DreamTokenTypes.NUMBER) return NUMBER_KEYS;
         if (tokenType == DreamTokenTypes.STRING) return STRING_KEYS;
-        if (tokenType == DreamTokenTypes.COMMENT ||
-            tokenType == DreamTokenTypes.COMMENTBLOCK ||
-            tokenType == DreamTokenTypes.COMMENTDOC) return COMMENT_KEYS;
+        if (tokenType == DreamTokenTypes.LINE_COMMENT ||
+            tokenType == DreamTokenTypes.BLOCK_COMMENT ||
+            tokenType == DreamTokenTypes.DOC_COMMENT) return COMMENT_KEYS;
         if (tokenType == DreamTokenTypes.OPERATOR) return OPERATOR_KEYS;
         if (tokenType == DreamTokenTypes.SEMICOLON) return SEMICOLON_KEYS;
         if (tokenType == DreamTokenTypes.COMMA) return COMMA_KEYS;

--- a/assets/jetbrains/src/main/java/com/dream/DreamTokenTypes.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamTokenTypes.java
@@ -2,19 +2,21 @@ package com.dream;
 
 import com.intellij.psi.tree.IElementType;
 
-public interface DreamTokenTypes {
-    IElementType KEYWORD = new DreamElementType("KEYWORD");
-    IElementType NUMBER = new DreamElementType("NUMBER");
-    IElementType STRING = new DreamElementType("STRING");
-    IElementType COMMENT = new DreamElementType("COMMENT");
-    IElementType COMMENTBLOCK = new DreamElementType("COMMENTBLOCK");
-    IElementType OPERATOR = new DreamElementType("OPERATOR");
-    IElementType SEMICOLON = new DreamElementType("SEMICOLON");
-    IElementType COMMA = new DreamElementType("COMMA");
-    IElementType DOT = new DreamElementType("DOT");
-    IElementType PAREN = new DreamElementType("PAREN");
-    IElementType BRACE = new DreamElementType("BRACE");
-    IElementType IDENTIFIER = new DreamElementType("IDENTIFIER");
-    IElementType BRACKET = new DreamElementType("BRACKET");
-    IElementType COMMENTDOC = new DreamElementType("COMMENTDOC");
+public final class DreamTokenTypes {
+    private DreamTokenTypes() {}
+
+    public static final IElementType KEYWORD = new DreamElementType("KEYWORD");
+    public static final IElementType NUMBER = new DreamElementType("NUMBER");
+    public static final IElementType STRING = new DreamElementType("STRING");
+    public static final IElementType LINE_COMMENT = new DreamElementType("LINE_COMMENT");
+    public static final IElementType BLOCK_COMMENT = new DreamElementType("BLOCK_COMMENT");
+    public static final IElementType DOC_COMMENT = new DreamElementType("DOC_COMMENT");
+    public static final IElementType OPERATOR = new DreamElementType("OPERATOR");
+    public static final IElementType SEMICOLON = new DreamElementType("SEMICOLON");
+    public static final IElementType COMMA = new DreamElementType("COMMA");
+    public static final IElementType DOT = new DreamElementType("DOT");
+    public static final IElementType PAREN = new DreamElementType("PAREN");
+    public static final IElementType BRACE = new DreamElementType("BRACE");
+    public static final IElementType BRACKET = new DreamElementType("BRACKET");
+    public static final IElementType IDENTIFIER = new DreamElementType("IDENTIFIER");
 }

--- a/assets/jetbrains/src/main/resources/tokens.json
+++ b/assets/jetbrains/src/main/resources/tokens.json
@@ -17,17 +17,17 @@
     "scope": "string.quoted.double"
   },
   {
-    "name": "commentDoc",
+    "name": "doc_comment",
     "regex": "/\\*\\*[^]*?\\*/|///.*",
     "scope": "comment.block.documentation"
   },
   {
-    "name": "comment",
+    "name": "line_comment",
     "regex": "//.*",
     "scope": "comment.line.double-slash"
   },
   {
-    "name": "commentBlock",
+    "name": "block_comment",
     "regex": "/\\*[\\s\\S]*?\\*/",
     "scope": "comment.block"
   },

--- a/assets/jetbrains/src/test/kotlin/com/dream/HighlightingTest.kt
+++ b/assets/jetbrains/src/test/kotlin/com/dream/HighlightingTest.kt
@@ -1,0 +1,16 @@
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.dream.DreamSyntaxHighlighter
+
+class HighlightingTest : BasePlatformTestCase() {
+    fun testHighlightingAttributes() {
+        val text = """// comment\nif true {\n  Console.WriteLine(\"hi\")\n}\n"""
+        val highlighter = DreamSyntaxHighlighter()
+        val lexer = highlighter.highlightingLexer
+        lexer.start(text)
+        while (lexer.tokenType != null) {
+            val keys = highlighter.getTokenHighlights(lexer.tokenType!!)
+            assertTrue("Attributes missing for ${lexer.tokenType}", keys.isNotEmpty())
+            lexer.advance()
+        }
+    }
+}

--- a/assets/jetbrains/tokens.json
+++ b/assets/jetbrains/tokens.json
@@ -17,17 +17,17 @@
     "scope": "string.quoted.double"
   },
   {
-    "name": "commentDoc",
+    "name": "doc_comment",
     "regex": "/\\*\\*[^]*?\\*/|///.*",
     "scope": "comment.block.documentation"
   },
   {
-    "name": "comment",
+    "name": "line_comment",
     "regex": "//.*",
     "scope": "comment.line.double-slash"
   },
   {
-    "name": "commentBlock",
+    "name": "block_comment",
     "regex": "/\\*[\\s\\S]*?\\*/",
     "scope": "comment.block"
   },


### PR DESCRIPTION
## Summary
- fix build with Java 21
- rename comment token types and regenerate the lexer
- update syntax highlighter mappings
- tweak token generator script and token definitions
- add light-platform test for token attributes
- document build steps for the JetBrains plugin

## Testing
- `gradle build`
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6879e741dff8832bbf3eb8aa9bee2036