### PR TITLE
[dreamc] update dream plugin lexer and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ npx vsce package
 
 ```bash
 cd assets/jetbrains
-./gradlew generateLexer build test
+gradle generateLexer build test
 ```
-Ensure a JDK 17 is available. The build regenerates the lexer from `tokens.def` before compiling and running the tests.
+Ensure JDK 17 is installed. The build regenerates the lexer from `DreamLexer.flex` before compiling and running the tests.
 
 The resulting VSIX and plugin zip live in their respective directories.
 

--- a/assets/jetbrains/src/main/java/com/dream/DreamTokenTypes.java
+++ b/assets/jetbrains/src/main/java/com/dream/DreamTokenTypes.java
@@ -2,19 +2,21 @@ package com.dream;
 
 import com.intellij.psi.tree.IElementType;
 
-public interface DreamTokenTypes {
-    IElementType KEYWORD = new DreamElementType("KEYWORD");
-    IElementType NUMBER = new DreamElementType("NUMBER");
-    IElementType STRING = new DreamElementType("STRING");
-    IElementType COMMENT = new DreamElementType("COMMENT");
-    IElementType COMMENTBLOCK = new DreamElementType("COMMENTBLOCK");
-    IElementType OPERATOR = new DreamElementType("OPERATOR");
-    IElementType SEMICOLON = new DreamElementType("SEMICOLON");
-    IElementType COMMA = new DreamElementType("COMMA");
-    IElementType DOT = new DreamElementType("DOT");
-    IElementType PAREN = new DreamElementType("PAREN");
-    IElementType BRACE = new DreamElementType("BRACE");
-    IElementType IDENTIFIER = new DreamElementType("IDENTIFIER");
-    IElementType BRACKET = new DreamElementType("BRACKET");
-    IElementType COMMENTDOC = new DreamElementType("COMMENTDOC");
+public final class DreamTokenTypes {
+    private DreamTokenTypes() {}
+
+    public static final IElementType KEYWORD = new DreamElementType("KEYWORD");
+    public static final IElementType NUMBER = new DreamElementType("NUMBER");
+    public static final IElementType STRING = new DreamElementType("STRING");
+    public static final IElementType COMMENT = new DreamElementType("COMMENT");
+    public static final IElementType COMMENTBLOCK = new DreamElementType("COMMENTBLOCK");
+    public static final IElementType OPERATOR = new DreamElementType("OPERATOR");
+    public static final IElementType SEMICOLON = new DreamElementType("SEMICOLON");
+    public static final IElementType COMMA = new DreamElementType("COMMA");
+    public static final IElementType DOT = new DreamElementType("DOT");
+    public static final IElementType PAREN = new DreamElementType("PAREN");
+    public static final IElementType BRACE = new DreamElementType("BRACE");
+    public static final IElementType IDENTIFIER = new DreamElementType("IDENTIFIER");
+    public static final IElementType BRACKET = new DreamElementType("BRACKET");
+    public static final IElementType COMMENTDOC = new DreamElementType("COMMENTDOC");
 }

--- a/assets/jetbrains/src/test/kotlin/com/dream/DreamHighlighterTest.kt
+++ b/assets/jetbrains/src/test/kotlin/com/dream/DreamHighlighterTest.kt
@@ -1,0 +1,22 @@
+import com.dream.DreamSyntaxHighlighter
+import com.dream.DreamLanguage
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class DreamHighlighterTest : BasePlatformTestCase() {
+    fun testTokensHaveAttributes() {
+        val text = "if true { \"hi\" } // comment"
+        val highlighter = SyntaxHighlighterFactory.getSyntaxHighlighter(DreamLanguage, project, null)
+        val lexer = highlighter.highlightingLexer
+        lexer.start(text)
+        while (lexer.tokenType != null) {
+            val type = lexer.tokenType!!
+            if (type !== com.intellij.psi.TokenType.WHITE_SPACE &&
+                type !== com.intellij.psi.TokenType.BAD_CHARACTER) {
+                val keys = highlighter.getTokenHighlights(type)
+                assertTrue("Token $type should have highlighting", keys.isNotEmpty())
+            }
+            lexer.advance()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor token types into a final class
- clean lexer comment rules and regenerate
- add light-platform syntax highlighting test
- document plugin build steps

## Testing
- `gradle test`
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_6879e741dff8832bbf3eb8aa9bee2036