### PR TITLE
[dreamc] Remove BOM from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-﻿* @Ddemon26
+* @Ddemon26


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Removed the UTF‑8 BOM from `CODEOWNERS` and added a trailing newline so the file conforms to standard text formatting.

Related Files
- `CODEOWNERS`

Changes
- Stripped BOM from the start of the file.
- Ensured the file ends with exactly one newline.

Testing
- `python/test_runner`

Dependencies
- None

Documentation
- None

Checklist
- [x] `zig build` *(not applicable: repo contains only tests and scripts)*
- [x] All test files under `tests/` compile using `python/test_runner`
- [ ] Documentation updated in `docs/` *(not applicable)*
- [ ] `codex/_startup.sh` updated if dependencies changed *(not applicable)*

Additional Notes
No functionality changes; only file formatting updated.

------
https://chatgpt.com/codex/tasks/task_e_687a029718c0832b9540a02140f68bfd