### PR TITLE
[dreamc] update docs for implemented features

### DIFF
--- a/docs/v1.1/arrays.md
+++ b/docs/v1.1/arrays.md
@@ -1,4 +1,12 @@
-# Arrays *(planned)*
+# Arrays
 
-Support for array types is planned but not yet implemented. Future versions will allow fixed-length arrays using bracket syntax similar to C.
+Dream.dr supports fixed-length arrays of primitive types. Declare them with square brackets:
+
+```dream
+int[3] nums = {1, 2, 3};
+char[5] letters;
+letters[0] = 'a';
+```
+
+Indexing is zero-based and arrays behave similarly to C arrays.
 

--- a/docs/v1.1/comments.md
+++ b/docs/v1.1/comments.md
@@ -1,4 +1,15 @@
-# Comments *(planned)*
+# Comments
 
-Single line comments using `//` are recognised. Block comments will be added later.
+Dream.dr recognises both single-line and block comments.
+
+- `//` introduces a comment until the end of the line.
+- `/* */` surrounds a block comment.
+
+```dream
+// one line
+/*
+   multiple
+   lines
+*/
+```
 

--- a/docs/v1.1/comparison.md
+++ b/docs/v1.1/comparison.md
@@ -1,4 +1,13 @@
-# Comparison *(planned)*
+# Comparison
 
-Equality and relational operators will allow comparing numbers and strings. Implementation work has not started yet.
+Dream.dr includes standard comparison operators:
+
+- `<`, `<=`, `>`, `>=` for numeric ordering
+- `==`, `!=` for equality tests on numbers and strings
+
+```dream
+if (a >= b) {
+    Console.WriteLine("a >= b");
+}
+```
 

--- a/docs/v1.1/conditional.md
+++ b/docs/v1.1/conditional.md
@@ -1,4 +1,8 @@
-# Conditional Operator *(planned)*
+# Conditional Operator
 
-The ternary `?:` operator will evaluate an expression based on a condition. It is not yet available in Dream.dr.
+The ternary `?:` chooses between two expressions based on a condition.
+
+```dream
+var result = condition ? "ok" : "fail";
+```
 

--- a/docs/v1.1/console.md
+++ b/docs/v1.1/console.md
@@ -1,4 +1,13 @@
-# Console Output *(planned)*
+# Console I/O
 
-A standard library for console I/O will provide `Console.WriteLine` and similar routines. Until then, output functions are stubbed.
+Dream's standard library exposes simple console functions.
+
+- `Console.Write` and `Console.WriteLine` output text.
+- `Console.ReadLine` reads a line from standard input.
+
+```dream
+Console.Write("Enter name: ");
+string name = Console.ReadLine();
+Console.WriteLine("Hello, " + name);
+```
 

--- a/docs/v1.1/if.md
+++ b/docs/v1.1/if.md
@@ -1,4 +1,12 @@
-# If Statements *(planned)*
+# If Statements
 
-Conditional execution using `if` and `else` will be added to control flow.
+`if` executes a block when its condition is true. An optional `else` block handles the opposite case.
+
+```dream
+if (flag) {
+    Console.WriteLine("yes");
+} else {
+    Console.WriteLine("no");
+}
+```
 

--- a/docs/v1.1/logical.md
+++ b/docs/v1.1/logical.md
@@ -1,4 +1,10 @@
-# Logical Operators *(planned)*
+# Logical Operators
 
-Support for `&&`, `||` and `!` is planned for conditional expressions and control flow.
+Use `&&`, `||` and `!` in expressions and control flow. These operators short-circuit like their C counterparts.
+
+```dream
+if (count > 0 && !done) {
+    Console.WriteLine("running");
+}
+```
 

--- a/docs/v1.1/loops.md
+++ b/docs/v1.1/loops.md
@@ -1,4 +1,19 @@
-# Loops *(planned)*
+# Loops
 
-`while`, `do` and `for` loops are planned. Example syntax will be provided once implemented.
+Dream.dr implements three looping constructs.
+
+- `while` evaluates its condition before each iteration.
+- `do` executes the body at least once before checking the condition.
+- `for` combines initialiser, condition and increment in one statement.
+
+`break` exits the nearest loop and `continue` skips to the next iteration.
+
+```dream
+var sum = 0;
+for (var i = 0; i < 10; i++) {
+    if (i == 5) continue;
+    sum += i;
+    if (sum > 40) break;
+}
+```
 

--- a/docs/v1.1/switch.md
+++ b/docs/v1.1/switch.md
@@ -1,4 +1,17 @@
-# Switch Statements *(planned)*
+# Switch Statements
 
-A `switch` construct will allow branching on integer values. It is not yet available.
+`switch` provides multi-way branching on integer values.
+
+```dream
+switch (value) {
+    case 1:
+        Console.WriteLine("one");
+        break;
+    case 2:
+        Console.WriteLine("two");
+        break;
+    default:
+        Console.WriteLine("other");
+}
+```
 


### PR DESCRIPTION
## Summary
- rewrite outdated v1.1 docs that still marked features as "planned"
- document loops, switch, arrays, comparison, logical ops, if/else, conditional operator, console I/O and comments

## Testing
- `zig build`
- `python/test_runner`

------
https://chatgpt.com/codex/tasks/task_e_687a028d4998832b90d81db1e2d66f20