### PR TITLE
[dreamc] handle null readline and expand debug console

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -30,6 +30,16 @@ Everything lives in a Linux terminal environment where you invoke `zig build` fo
 
 ---
 
+## Debug Console Helpers
+
+The compiler relies on helper functions in `src/util/console_debug.h` for
+printing diagnostics during development. `Console.Write`, `Console.WriteLine`,
+`Console.ReadLine` and `Console.Read` map to these helpers. When the
+`DREAM_RELEASE` macro is defined they become no-ops, so ensure any debugging
+calls are removed or guarded before release builds.
+
+---
+
 ## Testing Instructions
 
 * The CI plan lives at `.github/workflows/ci.yml`.

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -16,7 +16,7 @@ Version 1.1.0 (2025-07-16)
 - Fixed Windows build by replacing `mkstemps` with portable `tmpnam_s` fallback.
 - Restored generation of `build/bin/dream.c` when compiling `.dr` files.
 - Added support for primitive types (`int`, `float`, `char`, `bool`, `string`) in the parser and C code generation.
-- Introduced developer-only `Console.Write`/`WriteLine` macros for compiler debugging.
+- Introduced developer-only `Console.Write`, `WriteLine`, `ReadLine` and `Read` macros for compiler debugging.
 
 Version 1.1.01 (2025-07-17)
 - Documented current feature gaps in codex/FEATURES.md and added tasks/TODO.md.

--- a/docs/v1.1/console.md
+++ b/docs/v1.1/console.md
@@ -4,10 +4,15 @@ Dream's standard library exposes simple console functions.
 
 - `Console.Write` and `Console.WriteLine` output text.
 - `Console.ReadLine` reads a line from standard input.
+- `Console.Read` reads a single character from standard input.
 
 ```dream
 Console.Write("Enter name: ");
 string name = Console.ReadLine();
 Console.WriteLine("Hello, " + name);
 ```
+
+When building the compiler itself, these console methods are provided via
+`console_debug.h`. In debug mode they write to `stderr` (or read from `stdin`),
+while in release builds they compile to no-ops so the compiler remains silent.
 


### PR DESCRIPTION
## Summary
- return NULL on EOF in `dream_readline`
- add `dream_print` helpers and guard string prints
- extend debug console API with `ReadLine` and `Read`
- document console debugging helpers
- update documentation for console methods

## Testing
- `python/test_runner`

------
https://chatgpt.com/codex/tasks/task_e_687a0e7211a4832baa17727f99bb1854