### PR TITLE
[dreamc] add Console extern runtime

### DIFF
--- a/runtime/console.c
+++ b/runtime/console.c
@@ -1,0 +1,3 @@
+#include "console.h"
+void dr_console_write(const char* s) { printf("%s", s); }
+void dr_console_writeln(const char* s) { printf("%s\n", s); }

--- a/runtime/console.h
+++ b/runtime/console.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <stdio.h>
+void dr_console_write(const char* s);
+void dr_console_writeln(const char* s);

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -652,7 +652,7 @@ static void emit_stmt(CGCtx *ctx, COut *b, Node *n) {
         c_out_write(b, "dream_readline();");
         c_out_newline(b);
       } else if (is_string_expr(ctx, call->as.console.arg)) {
-        c_out_write(b, call->as.console.newline ? "dream_println(" : "dream_print(");
+        c_out_write(b, call->as.console.newline ? "dr_console_writeln(" : "dr_console_write(");
         emit_expr(ctx, b, call->as.console.arg);
         c_out_write(b, ");");
         c_out_newline(b);
@@ -676,7 +676,7 @@ static void emit_stmt(CGCtx *ctx, COut *b, Node *n) {
     if (n->as.console.read) {
       c_out_write(b, "dream_readline()");
     } else if (is_string_expr(ctx, n->as.console.arg)) {
-      c_out_write(b, n->as.console.newline ? "dream_println(" : "dream_print(");
+      c_out_write(b, n->as.console.newline ? "dr_console_writeln(" : "dr_console_write(");
       emit_expr(ctx, b, n->as.console.arg);
       c_out_write(b, ")");
     } else {
@@ -736,6 +736,8 @@ void codegen_emit_c(Node *root, FILE *out) {
   c_out_newline(&builder);
   c_out_write(&builder, "#include <setjmp.h>");
   c_out_newline(&builder);
+  c_out_write(&builder, "#include \"console.h\"");
+  c_out_newline(&builder);
   c_out_newline(&builder);
   c_out_write(&builder, "static jmp_buf dream_jmp_buf[16];\n");
   c_out_write(&builder, "static int dream_jmp_top = -1;\n");
@@ -758,14 +760,6 @@ void codegen_emit_c(Node *root, FILE *out) {
   c_out_write(&builder, "    size_t len = strlen(buf);\n");
   c_out_write(&builder, "    if (len && buf[len-1] == '\\n') buf[len-1] = 0;\n");
   c_out_write(&builder, "    return buf;\n}");
-  c_out_newline(&builder);
-  c_out_newline(&builder);
-  c_out_write(&builder, "static void dream_print(const char *s) {\n");
-  c_out_write(&builder, "    if (s) printf(\"%%s\", s); else printf(\"(null)\");\n");
-  c_out_write(&builder, "}\n");
-  c_out_write(&builder, "static void dream_println(const char *s) {\n");
-  c_out_write(&builder, "    if (s) printf(\"%%s\\n\", s); else printf(\"(null)\\n\");\n");
-  c_out_write(&builder, "}\n");
   c_out_newline(&builder);
   c_out_newline(&builder);
   for (size_t i = 0; i < root->as.block.len; i++) {

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -121,8 +121,16 @@ int main(int argc, char *argv[]) {
     if (!cc)
       cc = "zig cc";
     char cmd[256];
-    snprintf(cmd, sizeof(cmd), "%s build/bin/dream.c -o dream", cc);
+    snprintf(cmd, sizeof(cmd), "%s -c runtime/console.c -o build/console.o", cc);
     int res = system(cmd);
+    if (res != 0)
+      fprintf(stderr, "failed to run: %s\n", cmd);
+    snprintf(cmd, sizeof(cmd), "ar rcs build/libdruntime.a build/console.o");
+    res = system(cmd);
+    if (res != 0)
+      fprintf(stderr, "failed to run: %s\n", cmd);
+    snprintf(cmd, sizeof(cmd), "%s -Iruntime build/bin/dream.c -Lbuild -ldruntime -o dream", cc);
+    res = system(cmd);
     if (res != 0)
       fprintf(stderr, "failed to run: %s\n", cmd);
   } else if (emit_obj) {

--- a/stdlib/Console.dr
+++ b/stdlib/Console.dr
@@ -1,0 +1,11 @@
+// stdlib/Console.dr
+package stdlib;
+
+public class Console {
+  // Marked as external: implementations provided by the C runtime
+  @extern("dr_console_write")
+  public static extern void write(String s);
+
+  @extern("dr_console_writeln")
+  public static extern void writeln(String s);
+}


### PR DESCRIPTION
## Summary
- implement external `Console` runtime
- update code generation to use `dr_console_write` and `dr_console_writeln`
- compile runtime sources when producing programs

## Testing
- `zig build`
- `python3 codex/python/test_runner`

------
https://chatgpt.com/codex/tasks/task_e_687a45ae1498832bb112698ff775c416