### PR TITLE
[dreamc] add windows build and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ See the [changelog](docs/v1.1/changelog.md) for details on recent additions.
 
 ## Getting Started
 
-The steps below show how to build and use Dream on Linux. Windows support is experimental.
+The steps below show how to build and use Dream on Linux **or Windows**.
 
 1. **Install prerequisites**
-   - `sudo apt update && sudo apt install -y build-essential gcc git`
+   - On Linux:
+     ```bash
+     sudo apt update && sudo apt install -y build-essential gcc git
+     ```
+   - On Windows run `codex\_startup.ps1` from an elevated PowerShell (requires Chocolatey).
    - Install [Zig 0.15.0 or newer](https://ziglang.org/download/) and add `zig` to your `PATH`.
 2. **Clone the repository**
    ```bash
@@ -58,7 +62,7 @@ Compile a `.dr` file directly:
 This writes `build/bin/dream.c` and builds a runnable program called `dream` in the current directory. Execute it with:
 
 ```bash
-./dream
+./dream    # use `dream.exe` on Windows
 ```
 
 Example programs can be found in the [tests](tests) directory.

--- a/codex/_startup.ps1
+++ b/codex/_startup.ps1
@@ -1,0 +1,17 @@
+# Requires Chocolatey (https://chocolatey.org)
+Write-Host "Installing Dream compiler dependencies..."
+
+$packages = @(
+    'git',
+    'make',
+    'mingw',
+    'gdb',
+    're2c',
+    'zig'
+)
+
+foreach ($pkg in $packages) {
+    choco install $pkg -y
+}
+
+Write-Host "Dependency setup complete ✅"

--- a/codex/python/test_runner
+++ b/codex/python/test_runner
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import subprocess, re, sys
+import subprocess, re, sys, platform
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
@@ -24,7 +24,8 @@ def run_test(path: Path) -> bool:
         sys.stderr.write(res.stderr)
         print(f"[FAIL] {path} (compile error)")
         return False
-    res2 = subprocess.run([str(ROOT / 'dream')], capture_output=True, text=True)
+    exe = 'dream.exe' if platform.system() == 'Windows' else 'dream'
+    res2 = subprocess.run([str(ROOT / exe)], capture_output=True, text=True)
     if res2.returncode != 0:
         sys.stdout.write(res2.stdout)
         sys.stderr.write(res2.stderr)

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -125,6 +125,12 @@ int main(int argc, char *argv[]) {
     int res = system(cmd);
     if (res != 0)
       fprintf(stderr, "failed to run: %s\n", cmd);
+#ifdef _WIN32
+    snprintf(cmd, sizeof(cmd), "%s -Iruntime build/bin/dream.c build/console.o -o dream", cc);
+    res = system(cmd);
+    if (res != 0)
+      fprintf(stderr, "failed to run: %s\n", cmd);
+#else
     snprintf(cmd, sizeof(cmd), "ar rcs build/libdruntime.a build/console.o");
     res = system(cmd);
     if (res != 0)
@@ -133,6 +139,7 @@ int main(int argc, char *argv[]) {
     res = system(cmd);
     if (res != 0)
       fprintf(stderr, "failed to run: %s\n", cmd);
+#endif
   } else if (emit_obj) {
     codegen_emit_obj(root, "a.o");
   }


### PR DESCRIPTION
## Summary
- handle console runtime linking differently on Windows
- detect Windows in test runner for dream.exe
- document Windows setup in README
- add PowerShell startup script for Windows

## Testing
- `zig build`
- `python3 codex/python/test_runner | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687a5caeb734832b93531ad946e0f8bb