### PR TITLE
[dreamc] Add cross-platform utilities and Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: master
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential make gdb re2c
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install -y make mingw gdb re2c
+      - name: Build
+        run: zig build
+      - name: Run tests
+        run: python codex/python/test_runner
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install -y make mingw gdb re2c
+          choco install -y make mingw re2c
       - name: Build
         run: zig build
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The steps below show how to build and use Dream on Linux **or Windows**.
      ```bash
      sudo apt update && sudo apt install -y build-essential gcc git
      ```
-   - On Windows run `codex\_startup.ps1` from an elevated PowerShell (requires Chocolatey).
+   - On Windows run `codex\_startup.ps1` from an elevated PowerShell (requires Chocolatey). The script installs MinGW (with `gdb`) and other tools automatically.
    - Install [Zig 0.15.0 or newer](https://ziglang.org/download/) and add `zig` to your `PATH`.
 2. **Clone the repository**
    ```bash

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ The steps below show how to build and use Dream on Linux **or Windows**.
    ```
 3. **Build the compiler**
    ```bash
-   zig build
+   zig build             # detects your platform automatically
+   # cross-compile for Windows from Linux:
+   zig build -Dtarget=x86_64-windows
    ```
 4. **Compile a file**
    ```bash
@@ -46,7 +48,7 @@ The steps below show how to build and use Dream on Linux **or Windows**.
    ```
 5. **Run the tests**
    ```bash
-   ./python/test_runner
+   python codex/python/test_runner
    ```
 
 The resulting compiler binary is placed under `zig-out/bin`.

--- a/codex/_startup.ps1
+++ b/codex/_startup.ps1
@@ -5,7 +5,6 @@ $packages = @(
     'git',
     'make',
     'mingw',
-    'gdb',
     're2c',
     'zig'
 )

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -50,3 +50,4 @@ Version 1.1.04 (2025-07-19)
 - Improved cross-platform support for Linux and Windows.
 - Added `src/util/platform.h` and updated code to use it.
 - CI now builds and tests on Windows.
+- Updated Windows setup scripts to rely on MinGW's bundled gdb.

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -45,3 +45,8 @@ Version 1.1.03 (2025-07-18)
 - Added basic try/catch statements and the `throw` keyword.
 - Code generation now uses setjmp/longjmp for simple exception handling.
 - Updated grammar and added tests for exception handling.
+
+Version 1.1.04 (2025-07-19)
+- Improved cross-platform support for Linux and Windows.
+- Added `src/util/platform.h` and updated code to use it.
+- CI now builds and tests on Windows.

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -1,12 +1,11 @@
 #include "codegen.h"
+#include "../util/platform.h"
 #include "c_emit.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #ifdef _WIN32
 #include <io.h>
-#else
-#include <unistd.h>
 #endif
 
 /**
@@ -60,7 +59,8 @@ static const char *op_text(TokenKind k) {
   case TK_RSHIFTEQ:
     return ">>=";
   case TK_QMARKQMARKEQ:
-    return "?" "?=";
+    return "?"
+           "?=";
   case TK_TILDE:
     return "~";
   case TK_PLUSPLUS:
@@ -263,7 +263,8 @@ static int is_string_expr(CGCtx *ctx, Node *n) {
 /**
  * @brief Emits an expression node to the output buffer.
  *
- * Generates C code for the given expression node and writes it to the output buffer.
+ * Generates C code for the given expression node and writes it to the output
+ * buffer.
  *
  * @param ctx Pointer to the code generation context.
  * @param b Pointer to the output buffer.
@@ -274,7 +275,8 @@ static void emit_expr(CGCtx *ctx, COut *b, Node *n);
 /**
  * @brief Emits a statement node to the output buffer.
  *
- * Generates C code for the given statement node and writes it to the output buffer.
+ * Generates C code for the given statement node and writes it to the output
+ * buffer.
  *
  * @param ctx Pointer to the code generation context.
  * @param b Pointer to the output buffer.
@@ -285,7 +287,8 @@ static void emit_stmt(CGCtx *ctx, COut *b, Node *n);
 /**
  * @brief Emits a function node to the output buffer.
  *
- * Generates C code for the given function node and writes it to the output buffer.
+ * Generates C code for the given function node and writes it to the output
+ * buffer.
  *
  * @param b Pointer to the output buffer.
  * @param n Pointer to the function node.
@@ -295,9 +298,10 @@ static void emit_func(COut *b, Node *n);
 /**
  * @brief Emits an expression node to the output buffer.
  *
- * Generates C code for the given expression node and writes it to the output buffer.
- * Handles various node kinds, including literals, identifiers, unary and binary operations,
- * conditional expressions, array indexing, and function calls.
+ * Generates C code for the given expression node and writes it to the output
+ * buffer. Handles various node kinds, including literals, identifiers, unary
+ * and binary operations, conditional expressions, array indexing, and function
+ * calls.
  *
  * @param ctx Pointer to the code generation context.
  * @param b Pointer to the output buffer.
@@ -486,9 +490,10 @@ static void emit_func(COut *b, Node *n) {
 /**
  * @brief Emits a statement node to the output buffer.
  *
- * Generates C code for the given statement node and writes it to the output buffer.
- * Handles various statement types, including variable declarations, function definitions,
- * control flow statements (if, while, do-while, for, switch), and console calls.
+ * Generates C code for the given statement node and writes it to the output
+ * buffer. Handles various statement types, including variable declarations,
+ * function definitions, control flow statements (if, while, do-while, for,
+ * switch), and console calls.
  *
  * @param ctx Pointer to the code generation context.
  * @param b Pointer to the output buffer.
@@ -652,7 +657,8 @@ static void emit_stmt(CGCtx *ctx, COut *b, Node *n) {
         c_out_write(b, "dream_readline();");
         c_out_newline(b);
       } else if (is_string_expr(ctx, call->as.console.arg)) {
-        c_out_write(b, call->as.console.newline ? "dr_console_writeln(" : "dr_console_write(");
+        c_out_write(b, call->as.console.newline ? "dr_console_writeln("
+                                                : "dr_console_write(");
         emit_expr(ctx, b, call->as.console.arg);
         c_out_write(b, ");");
         c_out_newline(b);
@@ -676,7 +682,8 @@ static void emit_stmt(CGCtx *ctx, COut *b, Node *n) {
     if (n->as.console.read) {
       c_out_write(b, "dream_readline()");
     } else if (is_string_expr(ctx, n->as.console.arg)) {
-      c_out_write(b, n->as.console.newline ? "dr_console_writeln(" : "dr_console_write(");
+      c_out_write(b, n->as.console.newline ? "dr_console_writeln("
+                                           : "dr_console_write(");
       emit_expr(ctx, b, n->as.console.arg);
       c_out_write(b, ")");
     } else {
@@ -741,7 +748,8 @@ void codegen_emit_c(Node *root, FILE *out) {
   c_out_newline(&builder);
   c_out_write(&builder, "static jmp_buf dream_jmp_buf[16];\n");
   c_out_write(&builder, "static int dream_jmp_top = -1;\n");
-  c_out_write(&builder, "static void dream_throw(void) { longjmp(dream_jmp_buf[dream_jmp_top], 1); }\n");
+  c_out_write(&builder, "static void dream_throw(void) { "
+                        "longjmp(dream_jmp_buf[dream_jmp_top], 1); }\n");
   c_out_newline(&builder);
   c_out_write(&builder,
               "static char *dream_concat(const char *a, const char *b) {\n");
@@ -756,9 +764,11 @@ void codegen_emit_c(Node *root, FILE *out) {
   c_out_newline(&builder);
   c_out_write(&builder, "static char *dream_readline(void) {\n");
   c_out_write(&builder, "    static char buf[256];\n");
-  c_out_write(&builder, "    if (!fgets(buf, sizeof buf, stdin)) return NULL;\n");
+  c_out_write(&builder,
+              "    if (!fgets(buf, sizeof buf, stdin)) return NULL;\n");
   c_out_write(&builder, "    size_t len = strlen(buf);\n");
-  c_out_write(&builder, "    if (len && buf[len-1] == '\\n') buf[len-1] = 0;\n");
+  c_out_write(&builder,
+              "    if (len && buf[len-1] == '\\n') buf[len-1] = 0;\n");
   c_out_write(&builder, "    return buf;\n}");
   c_out_newline(&builder);
   c_out_newline(&builder);
@@ -797,8 +807,8 @@ void codegen_emit_c(Node *root, FILE *out) {
 /**
  * @brief Emits an object file for the given AST root node.
  *
- * Generates an intermediate C file from the AST, compiles it into an object file,
- * and writes the result to the specified path. Handles platform-specific
+ * Generates an intermediate C file from the AST, compiles it into an object
+ * file, and writes the result to the specified path. Handles platform-specific
  * temporary file creation and cleanup.
  *
  * @param root Pointer to the root node of the AST.
@@ -828,7 +838,7 @@ void codegen_emit_obj(Node *root, const char *path) {
   if (!f) {
     perror("fdopen");
     close(fd);
-    unlink(tmp);
+    dr_unlink(tmp);
     return;
   }
 #endif
@@ -839,9 +849,5 @@ void codegen_emit_obj(Node *root, const char *path) {
   int res = system(cmd);
   if (res != 0)
     fprintf(stderr, "failed to run: %s\n", cmd);
-#ifdef _WIN32
-  remove(tmp);
-#else
-  unlink(tmp);
-#endif
+  dr_unlink(tmp);
 }

--- a/src/util/platform.h
+++ b/src/util/platform.h
@@ -1,0 +1,21 @@
+#ifndef PLATFORM_H
+#define PLATFORM_H
+
+#ifdef _WIN32
+#include <direct.h>
+#define DR_PATH_SEP '\\'
+#define DR_PATH_SEP_STR "\\"
+#define DR_NEWLINE "\r\n"
+#define dr_mkdir(p) _mkdir(p)
+#define dr_unlink(p) remove(p)
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#define DR_PATH_SEP '/'
+#define DR_PATH_SEP_STR "/"
+#define DR_NEWLINE "\n"
+#define dr_mkdir(p) mkdir(p, 0755)
+#define dr_unlink(p) unlink(p)
+#endif
+
+#endif // PLATFORM_H


### PR DESCRIPTION
## What changed
- Introduced `src/util/platform.h` providing OS abstractions (path separators, newline, mkdir/unlink helpers)
- Updated `src/driver/main.c` and `src/codegen/codegen.c` to use the new helpers
- Added GitHub Actions workflow to build and test on both Linux and Windows
- Updated README with cross-compilation instructions and new test runner path
- Documented the changes in `docs/v1.1/changelog.md`

## How it was tested
- `zig build`
- `python codex/python/test_runner`

## Docs updated
- `README.md`
- `docs/v1.1/changelog.md`

## Dependencies
- None


------
https://chatgpt.com/codex/tasks/task_e_687a64c2cba0832b8298865ef2b19d3f