### PR TITLE
[dreamc] add simple SSA opt passes and test

### DIFF
--- a/codex/python/test_runner
+++ b/codex/python/test_runner
@@ -8,6 +8,7 @@ TEST_DIR = ROOT / 'tests'
 def run_test(path: Path) -> bool:
     text = path.read_text()
     matches = re.findall(r"//\s*Expected:\s*(.*)", text)
+    opts = re.findall(r"//\s*Options:\s*(.*)", text)
     if not matches:
         print(f"[SKIP] {path}")
         return True
@@ -18,7 +19,11 @@ def run_test(path: Path) -> bool:
             continue
         parts.append(m)
     expected = "\n".join(parts)
-    res = subprocess.run(['zig', 'build', 'run', '--', str(path)], capture_output=True, text=True, cwd=ROOT)
+    args = ['zig', 'build', 'run', '--']
+    if opts:
+        args.extend(opts[0].split())
+    args.append(str(path))
+    res = subprocess.run(args, capture_output=True, text=True, cwd=ROOT)
     if res.returncode != 0:
         sys.stdout.write(res.stdout)
         sys.stderr.write(res.stderr)

--- a/src/ir/ir.h
+++ b/src/ir/ir.h
@@ -47,4 +47,12 @@ struct IRInstr {
  */
 IRInstr *ir_instr_new(IROp op, IRValue dst, IRValue a, IRValue b);
 
+static inline IRValue ir_const(int v) {
+    IRValue r; r.id = -v - 1; return r;
+}
+
+static inline int ir_is_const(IRValue v) { return v.id < 0; }
+
+static inline int ir_const_value(IRValue v) { return -v.id - 1; }
+
 #endif

--- a/src/opt/dce.c
+++ b/src/opt/dce.c
@@ -5,8 +5,41 @@
  *
  * @param cfg Pointer to the control flow graph to optimize.
  */
+static int is_used(CFG *cfg, IRValue v) {
+    if (v.id < 0)
+        return 0;
+    for (size_t i = 0; i < cfg->nblocks; i++) {
+        BasicBlock *b = cfg->blocks[i];
+        for (size_t j = 0; j < b->ninstrs; j++) {
+            IRInstr *ins = b->instrs[j];
+            if ((ins->a.id == v.id || ins->b.id == v.id) && ins->op != IR_PHI)
+                return 1;
+        }
+    }
+    return 0;
+}
+
 void dce(CFG *cfg) {
-    // Simple dead code elimination placeholder.
-    // Would normally remove instructions with no side effects.
-    (void)cfg;
+    if (!cfg)
+        return;
+    for (size_t i = 0; i < cfg->nblocks; i++) {
+        BasicBlock *b = cfg->blocks[i];
+        size_t w = 0;
+        for (size_t j = 0; j < b->ninstrs; j++) {
+            IRInstr *ins = b->instrs[j];
+            switch (ins->op) {
+            case IR_BIN:
+            case IR_MOV:
+                if (!is_used(cfg, ins->dst)) {
+                    free(ins);
+                    continue;
+                }
+                break;
+            default:
+                break;
+            }
+            b->instrs[w++] = ins;
+        }
+        b->ninstrs = w;
+    }
 }

--- a/src/opt/sccp.c
+++ b/src/opt/sccp.c
@@ -30,6 +30,83 @@ typedef struct {
  *
  * @param cfg Pointer to the control flow graph to optimize.
  */
+static int max_value_id(CFG *cfg) {
+    int max = -1;
+    for (size_t i = 0; i < cfg->nblocks; i++) {
+        BasicBlock *b = cfg->blocks[i];
+        for (size_t j = 0; j < b->ninstrs; j++) {
+            IRInstr *ins = b->instrs[j];
+            if (ins->dst.id > max)
+                max = ins->dst.id;
+            if (ins->a.id > max)
+                max = ins->a.id;
+            if (ins->b.id > max)
+                max = ins->b.id;
+        }
+    }
+    return max + 1;
+}
+
+static IRValue fold_bin(IROp op, IRValue a, IRValue b) {
+    if (a.id >= 0 || b.id >= 0)
+        return (IRValue){0};
+    int lhs = -a.id - 1;
+    int rhs = -b.id - 1;
+    int res = 0;
+    switch (op) {
+    case IR_BIN:
+        res = lhs + rhs;
+        break;
+    default:
+        break;
+    }
+    return (IRValue){ .id = -res - 1 };
+}
+
 void sccp(CFG *cfg) {
-    (void)cfg;
+    if (!cfg)
+        return;
+    int nvals = max_value_id(cfg);
+    if (nvals <= 0)
+        return;
+    LatticeVal *vals = calloc((size_t)nvals, sizeof(LatticeVal));
+    for (size_t i = 0; i < cfg->nblocks; i++) {
+        BasicBlock *b = cfg->blocks[i];
+        for (size_t j = 0; j < b->ninstrs; j++) {
+            IRInstr *ins = b->instrs[j];
+            if (ins->op == IR_MOV && ins->a.id < 0) {
+                vals[ins->dst.id].kind = VAL_CONST;
+                vals[ins->dst.id].value = -ins->a.id - 1;
+            } else if (ins->op == IR_BIN && ins->a.id < 0 && ins->b.id < 0) {
+                int lhs = -ins->a.id - 1;
+                int rhs = -ins->b.id - 1;
+                vals[ins->dst.id].kind = VAL_CONST;
+                vals[ins->dst.id].value = lhs + rhs;
+            } else {
+                vals[ins->dst.id].kind = VAL_OVERDEF;
+            }
+        }
+    }
+    for (size_t i = 0; i < cfg->nblocks; i++) {
+        BasicBlock *b = cfg->blocks[i];
+        for (size_t j = 0; j < b->ninstrs; j++) {
+            IRInstr *ins = b->instrs[j];
+            if (ins->op == IR_MOV && vals[ins->dst.id].kind == VAL_CONST) {
+                ins->a.id = -vals[ins->dst.id].value - 1;
+            }
+            if (ins->op == IR_BIN) {
+                if (vals[ins->a.id].kind == VAL_CONST)
+                    ins->a.id = -vals[ins->a.id].value - 1;
+                if (vals[ins->b.id].kind == VAL_CONST)
+                    ins->b.id = -vals[ins->b.id].value - 1;
+                if (ins->a.id < 0 && ins->b.id < 0) {
+                    IRValue c = fold_bin(ins->op, ins->a, ins->b);
+                    ins->op = IR_MOV;
+                    ins->a = c;
+                    ins->b.id = 0;
+                }
+            }
+        }
+    }
+    free(vals);
 }

--- a/tests/advanced/ssa/constant_prop.dr
+++ b/tests/advanced/ssa/constant_prop.dr
@@ -1,0 +1,3 @@
+// Expected: 4
+// Options: -O1
+Console.WriteLine(2 + 2);


### PR DESCRIPTION
## What changed
- implemented basic constant helpers in `ir.h`
- fleshed out SCCP and DCE optimization passes
- updated test runner to parse `// Options:` for extra CLI args
- added regression test exercising `-O1` pipeline

## How it was tested
- `zig fmt --check build.zig`
- `zig build`
- `python codex/python/test_runner`

## Docs updated
- none

## Dependencies
- none

------
https://chatgpt.com/codex/tasks/task_e_687a6f29c89c832b9d8d9d7927111861