### PR TITLE
[dreamc] improve cross-platform build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           choco install -y make mingw re2c
       - name: Build
         run: zig build
+      - name: Cross-compile Windows binary
+        if: runner.os == 'Linux'
+        run: zig build -Dtarget=x86_64-windows-gnu
       - name: Run tests
         run: python codex/python/test_runner
         shell: bash

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The steps below show how to build and use Dream on Linux **or Windows**.
    ```bash
    zig build             # detects your platform automatically
    # cross-compile for Windows from Linux:
-   zig build -Dtarget=x86_64-windows
+   zig build -Dtarget=x86_64-windows-gnu
    ```
 4. **Compile a file**
    ```bash


### PR DESCRIPTION
### What changed
- added `DR_EXE_NAME` constant and path separator usage in `main.c`
- normalized Windows line endings when reading files
- updated README cross-compiling example
- extended CI to cross-build Windows target on Linux

### How it was tested
- `zig fmt --check build.zig`
- `zig build`
- `python codex/python/test_runner`

### Docs updated
- `README.md` cross-platform instructions

### Dependencies
- none

------
https://chatgpt.com/codex/tasks/task_e_687a769328d8832ba457d23d6f4dee45