### PR TITLE
[dreamc] add #line directives for debugging

### DIFF
--- a/docs/compiler/index.md
+++ b/docs/compiler/index.md
@@ -7,3 +7,7 @@ This section documents how to build and use the Dream compiler. It also covers t
 - [IntelliSense Setup](intellisense.md)
 
 Additional pages will be added here as the compiler grows.
+
+## Debugging
+
+Starting with version 1.1.07, the generated C code contains `#line` directives mapping back to the original `.dr` source. Compiler errors and debugger breakpoints therefore reference Dream source lines, making troubleshooting easier.

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -62,3 +62,6 @@ Version 1.1.05 (2025-07-20)
 Version 1.1.06 (2025-07-21)
 - Diagnostics now report line and column numbers.
 - Added `--verbose` flag for caret-highlighted messages.
+
+Version 1.1.07 (2025-07-22)
+- Generated C now includes `#line` directives to improve debugging back to Dream source.

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -10,14 +10,13 @@
  * @param root Pointer to the root node of the AST.
  * @param out Pointer to the output file.
  */
-void codegen_emit_c(Node *root, FILE *out);
+void codegen_emit_c(Node *root, FILE *out, const char *src_file);
 /**
  * @brief Emits an object file for the given AST root node.
  *
  * @param root Pointer to the root node of the AST.
  * @param path Path to the output object file.
  */
-void codegen_emit_obj(Node *root, const char *path);
+void codegen_emit_obj(Node *root, const char *path, const char *src_file);
 
 #endif
-

--- a/src/codegen/stmt.h
+++ b/src/codegen/stmt.h
@@ -1,19 +1,19 @@
 #ifndef CG_STMT_H
 #define CG_STMT_H
 
+#include "../parser/ast.h"
 #include "c_emit.h"
 #include "context.h"
 #include "expr.h"
-#include "../parser/ast.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void cg_emit_stmt(CGCtx *ctx, COut *b, Node *n);
-void emit_type_decl(COut *b, Node *n);
-void emit_func(COut *b, Node *n);
-void emit_method(COut *b, Slice class_name, Node *n);
+void cg_emit_stmt(CGCtx *ctx, COut *b, Node *n, const char *src_file);
+void emit_type_decl(COut *b, Node *n, const char *src_file);
+void emit_func(COut *b, Node *n, const char *src_file);
+void emit_method(COut *b, Slice class_name, Node *n, const char *src_file);
 
 typedef struct {
   Slice name;

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -145,30 +145,38 @@ int main(int argc, char *argv[]) {
     if (!cc)
       cc = "zig cc";
     char cmd[256];
-    snprintf(cmd, sizeof(cmd), "%s -c runtime%cconsole.c -o build%cconsole.o",
+    snprintf(cmd, sizeof(cmd), "%s -c \"runtime%cconsole.c\" -o \"build%cconsole.o\"",
              cc, DR_PATH_SEP, DR_PATH_SEP);
     int res = system(cmd);
-    if (res != 0)
+    if (res != 0) {
       fprintf(stderr, "failed to run: %s\n", cmd);
+      return 1;
+    }
 #ifdef _WIN32
     snprintf(cmd, sizeof(cmd),
-             "%s -Iruntime build%cbin%cdream.c build%cconsole.o -o %s", cc,
-             DR_PATH_SEP, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
+             "%s -Iruntime \"build%cbin%cdream.c\" \"build%cconsole.o\" -o \"%s\"",
+             cc, DR_PATH_SEP, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
     res = system(cmd);
-    if (res != 0)
+    if (res != 0) {
       fprintf(stderr, "failed to run: %s\n", cmd);
+      return 1;
+    }
 #else
     snprintf(cmd, sizeof(cmd), "ar rcs build%clibdruntime.a build%cconsole.o",
              DR_PATH_SEP, DR_PATH_SEP);
     res = system(cmd);
-    if (res != 0)
+    if (res != 0) {
       fprintf(stderr, "failed to run: %s\n", cmd);
+      return 1;
+    }
     snprintf(cmd, sizeof(cmd),
-             "%s -Iruntime build%cbin%cdream.c -Lbuild -ldruntime -o %s", cc,
-             DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
+             "%s -Iruntime \"build%cbin%cdream.c\" -Lbuild -ldruntime -o \"%s\"",
+             cc, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
     res = system(cmd);
-    if (res != 0)
+    if (res != 0) {
       fprintf(stderr, "failed to run: %s\n", cmd);
+      return 1;
+    }
 #endif
   } else if (emit_obj) {
     codegen_emit_obj(root, "a.o", input);

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -1,10 +1,10 @@
 #include "../codegen/codegen.h"
+#include "../ir/lower.h"
 #include "../lexer/lexer.h"
 #include "../opt/pipeline.h"
-#include "../ir/lower.h"
-#include "../ssa/ssa.h"
 #include "../parser/diagnostic.h"
 #include "../parser/parser.h"
+#include "../ssa/ssa.h"
 #include "../util/console_debug.h"
 #include "../util/platform.h"
 #include <stdio.h>
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
       perror("fopen");
       return 1;
     }
-    codegen_emit_c(root, out);
+    codegen_emit_c(root, out, input);
     fclose(out);
     const char *cc = getenv("CC");
     if (!cc)
@@ -152,8 +152,8 @@ int main(int argc, char *argv[]) {
       fprintf(stderr, "failed to run: %s\n", cmd);
 #ifdef _WIN32
     snprintf(cmd, sizeof(cmd),
-             "%s -Iruntime build%cbin%cdream.c build%cconsole.o -o %s",
-             cc, DR_PATH_SEP, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
+             "%s -Iruntime build%cbin%cdream.c build%cconsole.o -o %s", cc,
+             DR_PATH_SEP, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
     res = system(cmd);
     if (res != 0)
       fprintf(stderr, "failed to run: %s\n", cmd);
@@ -164,14 +164,14 @@ int main(int argc, char *argv[]) {
     if (res != 0)
       fprintf(stderr, "failed to run: %s\n", cmd);
     snprintf(cmd, sizeof(cmd),
-             "%s -Iruntime build%cbin%cdream.c -Lbuild -ldruntime -o %s",
-             cc, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
+             "%s -Iruntime build%cbin%cdream.c -Lbuild -ldruntime -o %s", cc,
+             DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
     res = system(cmd);
     if (res != 0)
       fprintf(stderr, "failed to run: %s\n", cmd);
 #endif
   } else if (emit_obj) {
-    codegen_emit_obj(root, "a.o");
+    codegen_emit_obj(root, "a.o", input);
   }
 
   free(src);

--- a/src/parser/ast.c
+++ b/src/parser/ast.c
@@ -11,9 +11,9 @@
  * @param a Pointer to the memory arena to initialize.
  */
 void arena_init(Arena *a) {
-    a->ptr = NULL;
-    a->len = 0;
-    a->cap = 0;
+  a->ptr = NULL;
+  a->len = 0;
+  a->cap = 0;
 }
 
 /**
@@ -26,11 +26,11 @@ void arena_init(Arena *a) {
  * @param min Minimum additional size required.
  */
 static void arena_grow(Arena *a, size_t min) {
-    size_t new_cap = a->cap ? a->cap * 2 : 4096;
-    if (new_cap < a->len + min)
-        new_cap = a->len + min;
-    a->ptr = realloc(a->ptr, new_cap);
-    a->cap = new_cap;
+  size_t new_cap = a->cap ? a->cap * 2 : 4096;
+  if (new_cap < a->len + min)
+    new_cap = a->len + min;
+  a->ptr = realloc(a->ptr, new_cap);
+  a->cap = new_cap;
 }
 
 /**
@@ -46,13 +46,13 @@ static void arena_grow(Arena *a, size_t min) {
  * @return Pointer to the allocated memory block.
  */
 void *arena_alloc(Arena *a, size_t size) {
-    if (a->len + size > a->cap)
-        arena_grow(a, size);
-    void *ptr = a->ptr + a->len;
-    a->len += size;
-    // zero memory for determinism
-    memset(ptr, 0, size);
-    return ptr;
+  if (a->len + size > a->cap)
+    arena_grow(a, size);
+  void *ptr = a->ptr + a->len;
+  a->len += size;
+  // zero memory for determinism
+  memset(ptr, 0, size);
+  return ptr;
 }
 
 /**
@@ -66,8 +66,8 @@ void *arena_alloc(Arena *a, size_t size) {
  * @return Pointer to the newly created node.
  */
 Node *node_new(Arena *a, NodeKind kind) {
-    Node *n = arena_alloc(a, sizeof(Node));
-    n->kind = kind;
-    return n;
+  Node *n = arena_alloc(a, sizeof(Node));
+  n->kind = kind;
+  n->pos = (Pos){0, 0};
+  return n;
 }
-

--- a/src/parser/ast.h
+++ b/src/parser/ast.h
@@ -121,6 +121,7 @@ typedef struct {
  */
 struct Node {
   NodeKind kind; /**< The type of the node. */
+  Pos pos;       /**< Source position of this node. */
   union {
     Slice lit;   /**< Literal value for ND_* literal nodes. */
     Slice ident; /**< Identifier for ND_IDENT nodes. */
@@ -144,7 +145,7 @@ struct Node {
     } index;
     struct {
       Node *object; /**< Object expression for ND_FIELD nodes. */
-      Slice name;  /**< Field name. */
+      Slice name;   /**< Field name. */
     } field;
     struct {
       TokenKind type;   /**< Variable type for ND_VAR_DECL nodes. */


### PR DESCRIPTION
## Summary
- track source position in `Node`
- plumb file name into codegen
- emit `#line` directives for functions
- adjust drivers for new codegen API

## Testing
- `python codex/python/test_runner`

------
https://chatgpt.com/codex/tasks/task_e_687a9a27f50c832b86787bc2d25be0d1