### PR TITLE
[dreamc] improve #line debugging

### DIFF
--- a/codex/python/check_line_directives.py
+++ b/codex/python/check_line_directives.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Verify that generated C includes #line directives for the given source."""
+import subprocess
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+if len(sys.argv) != 2:
+    print("usage: check_line_directives.py <source.dr>")
+    sys.exit(1)
+
+src = Path(sys.argv[1])
+res = subprocess.run(["zig", "build", "run", "--", str(src)], cwd=ROOT)
+if res.returncode != 0:
+    sys.exit(res.returncode)
+
+c_file = ROOT / "build" / "bin" / "dream.c"
+text = c_file.read_text()
+count = text.count(f'"{src.as_posix()}"')
+print(f"found {count} line directives for {src}")
+if count < 3:
+    print(text)
+    sys.exit(1)

--- a/docs/compiler/index.md
+++ b/docs/compiler/index.md
@@ -10,4 +10,4 @@ Additional pages will be added here as the compiler grows.
 
 ## Debugging
 
-Starting with version 1.1.07, the generated C code contains `#line` directives mapping back to the original `.dr` source. Compiler errors and debugger breakpoints therefore reference Dream source lines, making troubleshooting easier.
+Starting with version 1.1.07, the generated C code contains `#line` directives mapping back to the original `.dr` source. As of 1.1.12 these directives are emitted before every statement and the C compiler is invoked with `-g`, so debuggers step through the original Dream source.

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -85,3 +85,8 @@ Version 1.1.10 (2025-07-25)
 Version 1.1.11 (2025-08-01)
 - Introduced rudimentary reference counting for strings and class instances.
 - All allocations are tracked and freed on program exit.
+
+Version 1.1.12 (2025-08-05)
+- `#line` directives now appear before every statement for improved debugger
+  mapping.
+- Compiled binaries include debug symbols by passing `-g` to `zig cc`.

--- a/src/codegen/stmt.c
+++ b/src/codegen/stmt.c
@@ -93,8 +93,7 @@ void emit_type_decl(COut *b, Node *n, const char *src_file) {
   for (size_t i = 0; i < n->as.type_decl.len; i++) {
     Node *m = n->as.type_decl.members[i];
     if (m->kind == ND_VAR_DECL && m->as.var_decl.is_static) {
-      c_out_write(b, "%s %.*s_%.*s",
-                  type_to_c(m->as.var_decl.type),
+      c_out_write(b, "%s %.*s_%.*s", type_to_c(m->as.var_decl.type),
                   (int)n->as.type_decl.name.len, n->as.type_decl.name.start,
                   (int)m->as.var_decl.name.len, m->as.var_decl.name.start);
       if (m->as.var_decl.init) {
@@ -196,6 +195,11 @@ void emit_method(COut *b, Slice class_name, Node *n, const char *src_file) {
 }
 
 void cg_emit_stmt(CGCtx *ctx, COut *b, Node *n, const char *src_file) {
+  if (n->pos.line) {
+    if (!b->at_line_start)
+      c_out_newline(b);
+    c_out_write(b, "#line %zu \"%s\"\n", n->pos.line, src_file);
+  }
   switch (n->kind) {
   case ND_VAR_DECL:
     if (n->as.var_decl.array_len > 0) {

--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -160,7 +160,7 @@ int main(int argc, char *argv[]) {
     const char *optflag =
         opt_level >= 3 ? "-O3" : (opt_level >= 2 ? "-O2" : "");
     snprintf(cmd, sizeof(cmd),
-             "%s %s -c \"runtime%cconsole.c\" -o \"build%cconsole.o\"", cc,
+             "%s -g %s -c \"runtime%cconsole.c\" -o \"build%cconsole.o\"", cc,
              optflag, DR_PATH_SEP, DR_PATH_SEP);
     int res = system(cmd);
     if (res != 0) {
@@ -168,7 +168,7 @@ int main(int argc, char *argv[]) {
       return 1;
     }
     snprintf(cmd, sizeof(cmd),
-             "%s %s -c \"runtime%cmemory.c\" -o \"build%cmemory.o\"", cc,
+             "%s -g %s -c \"runtime%cmemory.c\" -o \"build%cmemory.o\"", cc,
              optflag, DR_PATH_SEP, DR_PATH_SEP);
     res = system(cmd);
     if (res != 0) {
@@ -177,7 +177,7 @@ int main(int argc, char *argv[]) {
     }
 #ifdef _WIN32
     snprintf(cmd, sizeof(cmd),
-             "%s %s -Iruntime \"build%cbin%cdream.c\" \"build%cconsole.o\" "
+             "%s -g %s -Iruntime \"build%cbin%cdream.c\" \"build%cconsole.o\" "
              "\"build%cmemory.o\" -o \"%s\"",
              cc, optflag, DR_PATH_SEP, DR_PATH_SEP, DR_PATH_SEP, DR_PATH_SEP,
              DR_EXE_NAME);
@@ -195,10 +195,10 @@ int main(int argc, char *argv[]) {
       fprintf(stderr, "failed to run: %s\n", cmd);
       return 1;
     }
-    snprintf(
-        cmd, sizeof(cmd),
-        "%s %s -Iruntime \"build%cbin%cdream.c\" -Lbuild -ldruntime -o \"%s\"",
-        cc, optflag, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
+    snprintf(cmd, sizeof(cmd),
+             "%s -g %s -Iruntime \"build%cbin%cdream.c\" -Lbuild -ldruntime -o "
+             "\"%s\"",
+             cc, optflag, DR_PATH_SEP, DR_PATH_SEP, DR_EXE_NAME);
     res = system(cmd);
     if (res != 0) {
       fprintf(stderr, "failed to run: %s\n", cmd);

--- a/tests/debug/line_directives.dr
+++ b/tests/debug/line_directives.dr
@@ -1,0 +1,5 @@
+// Expected: 1
+int x = 1;
+if (x > 0) {
+    Console.WriteLine(x);
+}


### PR DESCRIPTION
## What changed
- inserted `#line` directives before each statement when generating C
- normalized source paths consistently
- compiled runtime with `-g` to emit debug info
- added helper `check_line_directives.py` and regression test
- documented enhanced debugging

## How it was tested
- `python codex/python/test_runner`
- `python codex/python/check_line_directives.py tests/debug/line_directives.dr`

## Docs updated
- `docs/compiler/index.md`
- `docs/v1.1/changelog.md`

## Dependencies
- none

------
https://chatgpt.com/codex/tasks/task_e_687bb45256bc832b948b9a5e359cdc61