### PR TITLE
Fix runtime library integration

### DIFF
--- a/codex/test_runtime_integration.ps1
+++ b/codex/test_runtime_integration.ps1
@@ -85,6 +85,14 @@ foreach ($target in $targets) {
     }
 }
 
+# Test 6: Custom runtime library detection
+Write-Host "`nTest 6: Custom Runtime Library" -ForegroundColor Yellow
+if (Test-Path "build/custom.o" -or (Test-Path "build/libdruntime.a" -and (ar t "build/libdruntime.a" | Select-String -Quiet "custom.o"))) {
+    Write-Host "✓ Test 6 PASSED: custom runtime library compiled" -ForegroundColor Green
+} else {
+    Write-Host "✗ Test 6 FAILED: custom runtime object missing" -ForegroundColor Red
+}
+
 # Cleanup temporary files
 Remove-Item "tests/temp_test*.dr" -ErrorAction SilentlyContinue
 

--- a/codex/test_runtime_integration.sh
+++ b/codex/test_runtime_integration.sh
@@ -109,6 +109,14 @@ else
     echo -e "${RED}✗ Test 6 FAILED: Could not generate C code${NC}"
 fi
 
+# Test 7: Custom runtime library detection
+echo -e "\n${YELLOW}Test 7: Custom Runtime Library${NC}"
+if [ -f "build/custom.o" ] || ( [ -f "build/libdruntime.a" ] && ar t build/libdruntime.a | grep -q custom.o ); then
+    echo -e "${GREEN}✓ Test 7 PASSED: custom runtime library compiled${NC}"
+else
+    echo -e "${RED}✗ Test 7 FAILED: custom runtime object missing${NC}"
+fi
+
 # Cleanup temporary files
 rm -f tests/temp_test*.dr
 

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -1,0 +1,2 @@
+#include "custom.h"
+int dr_custom_value(void) { return 42; }

--- a/runtime/custom.h
+++ b/runtime/custom.h
@@ -1,0 +1,4 @@
+#ifndef DR_CUSTOM_H
+#define DR_CUSTOM_H
+int dr_custom_value(void);
+#endif

--- a/src/codegen/codegen.c
+++ b/src/codegen/codegen.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <dirent.h>
 #ifdef _WIN32
 #include <io.h>
 #endif
@@ -20,8 +21,21 @@ void codegen_emit_c(Node *root, FILE *out, const char *src_file) {
   c_out_write(&builder, "#include <string.h>\n");
   c_out_write(&builder, "#include <stdlib.h>\n");
   c_out_write(&builder, "#include <setjmp.h>\n");
-  c_out_write(&builder, "#include \"console.h\"\n");
-  c_out_write(&builder, "#include \"memory.h\"\n\n");
+
+  DIR *hdr_dir = opendir("runtime");
+  if (hdr_dir) {
+    struct dirent *ent;
+    while ((ent = readdir(hdr_dir))) {
+      size_t len = strlen(ent->d_name);
+      if (len > 2 && strcmp(ent->d_name + len - 2, ".h") == 0) {
+        c_out_write(&builder, "#include \"");
+        c_out_write(&builder, ent->d_name);
+        c_out_write(&builder, "\"\n");
+      }
+    }
+    closedir(hdr_dir);
+    c_out_newline(&builder);
+  }
 
   c_out_write(&builder, "static jmp_buf dream_jmp_buf[16];\n");
   c_out_write(&builder, "static int dream_jmp_top = -1;\n");


### PR DESCRIPTION
## Summary
- detect all runtime headers for inclusion
- compile all runtime source files automatically
- add a simple custom runtime module
- extend runtime integration scripts to verify custom libs

## Testing
- `./codex/test_cli.sh quick` *(fails: integration, unit, regression, semantic)*

------
https://chatgpt.com/codex/tasks/task_e_687be0441c28832ba378e9b9912be47f