### PR TITLE
Add cross-platform Vulkan loader stub

### DIFF
--- a/src/runtime/vulkan_stub.c
+++ b/src/runtime/vulkan_stub.c
@@ -1,6 +1,31 @@
-#include <vulkan/vulkan_core.h>
+#ifdef _WIN32
+#define VK_USE_PLATFORM_WIN32_KHR
+#include <windows.h>
+#elif defined(__linux__)
+#define VK_USE_PLATFORM_XCB_KHR
+#include <xcb/xcb.h>
+#endif
+
+#include <vulkan/vulkan.h>
 #include "vulkan_stub.h"
 
 int dr_vulkan_available(void) {
     return vkGetInstanceProcAddr(VK_NULL_HANDLE, "vkGetInstanceProcAddr") != NULL;
+}
+
+uint32_t dr_vulkan_version(void) {
+    PFN_vkEnumerateInstanceVersion pfn =
+        (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(VK_NULL_HANDLE, "vkEnumerateInstanceVersion");
+    if (!pfn) return 0;
+    uint32_t version = 0;
+    if (pfn(&version) != VK_SUCCESS) return 0;
+    return version;
+}
+
+PFN_vkVoidFunction dr_load_instance_proc(VkInstance instance, const char *name) {
+    return vkGetInstanceProcAddr(instance, name);
+}
+
+PFN_vkVoidFunction dr_load_device_proc(VkDevice device, const char *name) {
+    return vkGetDeviceProcAddr(device, name);
 }

--- a/src/runtime/vulkan_stub.h
+++ b/src/runtime/vulkan_stub.h
@@ -1,6 +1,20 @@
 #ifndef DR_VULKAN_STUB_H
 #define DR_VULKAN_STUB_H
 
+#include <stdint.h>
+#include <vulkan/vulkan_core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int dr_vulkan_available(void);
+uint32_t dr_vulkan_version(void);
+PFN_vkVoidFunction dr_load_instance_proc(VkInstance instance, const char *name);
+PFN_vkVoidFunction dr_load_device_proc(VkDevice device, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // DR_VULKAN_STUB_H


### PR DESCRIPTION
## Summary
- extend Vulkan stub header for version and function pointer loading helpers
- define platform surface extensions for Win32 and XCB in the Vulkan stub
- expose helper to fetch Vulkan API version and load procs

## Testing
- `zig build`
- `./codex/test_cli.sh quick`

------
https://chatgpt.com/codex/tasks/task_e_687c9eae717c832bbe1f63b82199090e