### PR TITLE
[dreamc] add Vulkan type definitions

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -35,6 +35,7 @@
 - Object construction for classes and structs
 - Instance methods on classes (emitted as C functions with a `this` pointer)
 - Exception handling with `try`/`catch` statements and `throw`
+- Vulkan handle and struct definitions for interop with the Vulkan API
 
 ## Missing Features
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,6 +95,7 @@
                         <li><a href="#" data-md="modules.md">Multi-file Compilation</a></li>
                         <li><a href="#" data-md="memory.md">Memory Management</a></li>
                         <li><a href="#" data-md="interop.md">C Interoperability</a></li>
+                        <li><a href="#" data-md="vulkan.md">Vulkan Types</a></li>
                     </ul>
                 </li>
                 
@@ -189,7 +190,7 @@
                 'arithmetic.md', 'comparison.md', 'logical.md', 'conditional.md', 'bitwise.md',
                 'if.md', 'loops.md', 'switch.md', 'return.md',
                 'functions.md', 'console.md', 'comments.md',
-                'changelog.md', 'architecture.md', 'parentheses.md'
+                'changelog.md', 'architecture.md', 'parentheses.md', 'vulkan.md'
             ];
             
             // Version-independent index pages

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -99,7 +99,8 @@ Handle user interaction and data exchange with the console and external systems.
 ### 🔧 Advanced Topics
 1. **[Bitwise Operations](v1.1/bitwise.md)** - Low-level programming
 2. **[C Interoperability](interop.md)** - System integration
-3. **[Grammar Specification](grammar/Grammar.md)** - Language internals
+3. **[Vulkan Types](v1.1/vulkan.md)** - Vulkan handle representations
+4. **[Grammar Specification](grammar/Grammar.md)** - Language internals
 
 ## Code Examples
 

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -90,3 +90,6 @@ Version 1.1.12 (2025-08-05)
 - `#line` directives now appear before every statement for improved debugger
   mapping.
 - Compiled binaries include debug symbols by passing `-g` to `zig cc`.
+
+Version 1.1.13 (2025-08-10)
+- Introduced Vulkan handle and struct definitions in the standard library.

--- a/docs/v1.1/vulkan.md
+++ b/docs/v1.1/vulkan.md
@@ -1,0 +1,13 @@
+# Vulkan Types
+
+Dream's standard library provides minimal bindings for core Vulkan handles and structures. Handles are opaque 64-bit integers while enums mirror common Vulkan result codes.
+
+```dream
+// Creating instance information
+VkApplicationInfo info = new VkApplicationInfo();
+info.applicationName = "My App";
+info.engineName = "DreamEngine";
+info.apiVersion = 0x00400000; // Vulkan 1.4
+```
+
+These definitions allow Dream programs to prepare data for C functions that expect Vulkan-compatible structs.

--- a/stdlib/Vulkan.dr
+++ b/stdlib/Vulkan.dr
@@ -1,0 +1,43 @@
+package stdlib;
+
+// Basic Vulkan handle representation using a 64-bit integer
+public struct VkHandle {
+  long value;
+}
+
+// Opaque handles for common Vulkan objects
+public struct VkInstance { long value; }
+public struct VkPhysicalDevice { long value; }
+public struct VkDevice { long value; }
+public struct VkQueue { long value; }
+public struct VkCommandBuffer { long value; }
+public struct VkSurfaceKHR { long value; }
+public struct VkSwapchainKHR { long value; }
+
+// Primary result codes returned by Vulkan functions
+public enum VkResult {
+  Success = 0,
+  NotReady = 1,
+  Timeout = 2,
+  EventSet = 3,
+  EventReset = 4,
+  Incomplete = 5,
+  ErrorOutOfHostMemory = -1,
+  ErrorOutOfDeviceMemory = -2,
+  ErrorInitializationFailed = -3,
+  ErrorDeviceLost = -4,
+}
+
+// Minimal subset of VkApplicationInfo for instance creation
+public struct VkApplicationInfo {
+  string applicationName;
+  string engineName;
+  uint   apiVersion;
+}
+
+// Minimal subset of VkInstanceCreateInfo referencing application info
+public struct VkInstanceCreateInfo {
+  VkApplicationInfo* appInfo;
+  uint enabledExtensionCount;
+  long ppEnabledExtensionNames; // char*[] pointer
+}


### PR DESCRIPTION
Dream Compiler Pull Request

Description
Added Vulkan handle and struct representations in the Dream standard library. Updated documentation navigation and changelog. Included brief Vulkan usage doc and noted feature in FEATURES.md.

Related Files
- `stdlib/Vulkan.dr`
- `docs/v1.1/vulkan.md`
- `docs/index.html`
- `docs/language-reference.md`
- `codex/FEATURES.md`
- `docs/v1.1/changelog.md`

Changes
- New Vulkan handle structs and `VkResult` enum mirror core Vulkan objects.
- Added doc page describing these types and linked from the site navigation.
- Updated language reference advanced topics and changelog.
- Documented feature in FEATURES.md.

Testing
```bash
zig build --summary all
python3 codex/test_cli.py quick
```

Dependencies
None.

Documentation
- Added `docs/v1.1/vulkan.md` and linked from navigation.
- Updated changelog entry for v1.1.13.

Checklist
- [x] `zig build` succeeds
- [x] All test files under `tests/` compile using `python3 codex/test_cli.py quick`
- [x] Documentation updated in `docs/`
- [ ] `codex/_startup.sh` updated if dependencies changed

Additional Notes
N/A

------
https://chatgpt.com/codex/tasks/task_e_687ca1ac9118832bb8e5b4bc543b841b