### PR TITLE
[dreamc] Add Vulkan helper for device enumeration

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,7 +51,10 @@ pub fn build(b: *std.Build) void {
     // Collect runtime sources, adding Vulkan stub if available
     var runtime_sources = std.ArrayList([]const u8).init(b.allocator);
     for (BaseRuntimeSources) |s| runtime_sources.append(s) catch unreachable;
-    if (vk_include != null) runtime_sources.append("src/runtime/vulkan_stub.c") catch unreachable;
+    if (vk_include != null) {
+        runtime_sources.append("src/runtime/vulkan_stub.c") catch unreachable;
+        runtime_sources.append("src/runtime/vulkan_helpers.c") catch unreachable;
+    }
 
     // Add debug mode option for enhanced debugging support
     const debug_mode = b.option(bool, "debug", "Enable enhanced debug information for Dream source debugging") orelse false;

--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -36,6 +36,7 @@
 - Instance methods on classes (emitted as C functions with a `this` pointer)
 - Exception handling with `try`/`catch` statements and `throw`
 - Vulkan handle and struct definitions for interop with the Vulkan API
+- Vulkan helper `dr_vk_enumerate_physical_devices` returns available devices
 
 ## Missing Features
 

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -93,3 +93,7 @@ Version 1.1.12 (2025-08-05)
 
 Version 1.1.13 (2025-08-10)
 - Introduced Vulkan handle and struct definitions in the standard library.
+
+Version 1.1.14 (2025-08-15)
+- Added `dr_vk_enumerate_physical_devices` runtime helper returning a list of
+  available devices.

--- a/docs/v1.1/vulkan.md
+++ b/docs/v1.1/vulkan.md
@@ -11,3 +11,14 @@ info.apiVersion = 0x00400000; // Vulkan 1.4
 ```
 
 These definitions allow Dream programs to prepare data for C functions that expect Vulkan-compatible structs.
+
+## Enumerating Physical Devices
+
+The runtime provides a small helper to obtain the list of available physical devices without manual pointer juggling:
+
+```dream
+VkPhysicalDeviceList list = Vulkan.enumeratePhysicalDevices(instance);
+Console.WriteLine(list.count);
+```
+
+The returned `VkPhysicalDeviceList` struct contains a pointer to the devices array and a `count` field. Memory for the array is allocated with `dr_alloc` and should be released with `dr_release` when no longer needed.

--- a/src/runtime/vulkan_helpers.c
+++ b/src/runtime/vulkan_helpers.c
@@ -1,0 +1,22 @@
+#include "vulkan_helpers.h"
+#include "memory.h"
+#include <vulkan/vulkan.h>
+
+DrVkDeviceList dr_vk_enumerate_physical_devices(VkInstance instance) {
+  DrVkDeviceList list = {0};
+  uint32_t count = 0;
+  if (vkEnumeratePhysicalDevices(instance, &count, NULL) != VK_SUCCESS ||
+      count == 0)
+    return list;
+  list.devices = dr_alloc(sizeof(VkPhysicalDevice) * count);
+  if (!list.devices)
+    return list;
+  if (vkEnumeratePhysicalDevices(instance, &count, list.devices) !=
+      VK_SUCCESS) {
+    dr_release(list.devices);
+    list.devices = NULL;
+    return list;
+  }
+  list.count = count;
+  return list;
+}

--- a/src/runtime/vulkan_helpers.h
+++ b/src/runtime/vulkan_helpers.h
@@ -1,0 +1,22 @@
+#ifndef DR_VULKAN_HELPERS_H
+#define DR_VULKAN_HELPERS_H
+
+#include <stdint.h>
+#include <vulkan/vulkan_core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct DrVkDeviceList {
+  VkPhysicalDevice *devices;
+  uint32_t count;
+} DrVkDeviceList;
+
+DrVkDeviceList dr_vk_enumerate_physical_devices(VkInstance instance);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DR_VULKAN_HELPERS_H

--- a/stdlib/Vulkan.dr
+++ b/stdlib/Vulkan.dr
@@ -14,6 +14,12 @@ public struct VkCommandBuffer { long value; }
 public struct VkSurfaceKHR { long value; }
 public struct VkSwapchainKHR { long value; }
 
+// Helper structure returned by Vulkan.enumeratePhysicalDevices
+public struct VkPhysicalDeviceList {
+  VkPhysicalDevice* devices;
+  uint count;
+}
+
 // Primary result codes returned by Vulkan functions
 public enum VkResult {
   Success = 0,
@@ -40,4 +46,9 @@ public struct VkInstanceCreateInfo {
   VkApplicationInfo* appInfo;
   uint enabledExtensionCount;
   long ppEnabledExtensionNames; // char*[] pointer
+}
+
+public class Vulkan {
+  @extern("dr_vk_enumerate_physical_devices")
+  public static extern VkPhysicalDeviceList enumeratePhysicalDevices(VkInstance instance);
 }

--- a/tasks/TODO.md
+++ b/tasks/TODO.md
@@ -13,3 +13,7 @@ Keep the grammar and documentation up to date once these features land.
 - tests/advanced/oop/class.dr
 - tests/advanced/oop/type.dr
 - tests/basics/io/readline.dr
+
+## Vulkan Roadmap
+- Support passing arrays and by-ref parameters to extern functions
+- Investigate `out` keyword for returning values from Vulkan calls


### PR DESCRIPTION
## What changed
- added runtime helper `dr_vk_enumerate_physical_devices` and header
- integrated new helper into build when Vulkan SDK is present
- declared `Vulkan.enumeratePhysicalDevices` in the standard library
- documented enumeration support and updated changelog
- noted feature in FEATURES.md and TODO roadmap

## How it was tested
- `zig build`
- `./codex/test_cli.sh quick` *(fails expected tests)*

## Docs updated
- `docs/v1.1/vulkan.md`
- `docs/v1.1/changelog.md`

## Dependencies
- none

------
https://chatgpt.com/codex/tasks/task_e_687ca41e0fc0832bbd67f3ee66739230