### PR TITLE
[dreamc] add Vulkan runtime wrappers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,11 +17,8 @@ const AllCSources = [_][]const u8{
 
 /// Baseline runtime sources always compiled
 const BaseRuntimeSources = [_][]const u8{
-    "src/runtime/memory.c",
-    "src/runtime/console.c",
-    "src/runtime/custom.c",
-    "src/runtime/task.c",
-    "src/runtime/exception.c",
+    "src/runtime/memory.c", "src/runtime/console.c",   "src/runtime/custom.c",
+    "src/runtime/task.c",   "src/runtime/exception.c",
 };
 
 const CFLAGS = [_][]const u8{
@@ -29,7 +26,8 @@ const CFLAGS = [_][]const u8{
 };
 
 const DEBUG_CFLAGS = [_][]const u8{
-    "-std=c11", "-Wall", "-Wextra", "-D_GNU_SOURCE", "-Isrc/lexer", "-g", "-O0", "-DDREAM_DEBUG",
+    "-std=c11",      "-Wall", "-Wextra", "-D_GNU_SOURCE", "-Isrc/lexer", "-g", "-O0",
+    "-DDREAM_DEBUG",
 };
 
 /// Builds the project by defining targets, modules, and build steps.
@@ -40,12 +38,17 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     // Detect Vulkan SDK paths from environment
-    const vulkan_sdk = std.process.getEnvVarOwned(b.allocator, "VULKAN_SDK") catch null;
+    const vulkan_sdk =
+        std.process.getEnvVarOwned(b.allocator, "VULKAN_SDK") catch null;
     var vk_include: ?[]const u8 = null;
     var vk_lib: ?[]const u8 = null;
     if (vulkan_sdk) |sdk| {
-        vk_include = b.pathJoin(&.{ sdk, if (target.result.os.tag == .windows) "Include" else "include" });
-        vk_lib = b.pathJoin(&.{ sdk, if (target.result.os.tag == .windows) "Lib" else "lib" });
+        vk_include = b.pathJoin(&.{
+            sdk,
+            if (target.result.os.tag == .windows) "Include" else "include",
+        });
+        vk_lib =
+            b.pathJoin(&.{ sdk, if (target.result.os.tag == .windows) "Lib" else "lib" });
     }
 
     // Collect runtime sources, adding Vulkan stub if available
@@ -54,10 +57,12 @@ pub fn build(b: *std.Build) void {
     if (vk_include != null) {
         runtime_sources.append("src/runtime/vulkan_stub.c") catch unreachable;
         runtime_sources.append("src/runtime/vulkan_helpers.c") catch unreachable;
+        runtime_sources.append("src/runtime/vulkan.c") catch unreachable;
     }
 
     // Add debug mode option for enhanced debugging support
-    const debug_mode = b.option(bool, "debug", "Enable enhanced debug information for Dream source debugging") orelse false;
+    const debug_mode =
+        b.option(bool, "debug", "Enable enhanced debug information for Dream source debugging") orelse false;
 
     const exe_mod = b.createModule(.{ .target = target, .optimize = optimize });
     const bootstrap_mod =
@@ -126,7 +131,8 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     // Debug build step
-    const debug_step = b.step("debug", "Build DreamCompiler with enhanced debug information");
+    const debug_step =
+        b.step("debug", "Build DreamCompiler with enhanced debug information");
     debug_step.dependOn(&exe.step);
 
     // Create runtime library for linking with generated code
@@ -150,8 +156,10 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(runtime_lib);
 
     // Multi-file compilation step
-    const multifile_step = b.step("compile-multi", "Compile multiple .dr files with linking");
-    const multifile_cmd = addMultiFileCompileStep(b, exe, runtime_lib, target, optimize);
+    const multifile_step =
+        b.step("compile-multi", "Compile multiple .dr files with linking");
+    const multifile_cmd =
+        addMultiFileCompileStep(b, exe, runtime_lib, target, optimize);
     multifile_step.dependOn(multifile_cmd);
 
     const test_step = b.step("test", "Run compiler tests");
@@ -230,8 +238,8 @@ fn addCompileDrStep(
 
 /// Adds a multi-file compilation and linking step
 ///
-/// This function supports compiling multiple .dr files and linking them together
-/// with the runtime library to create a final executable.
+/// This function supports compiling multiple .dr files and linking them
+/// together with the runtime library to create a final executable.
 ///
 /// @param b The build context
 /// @param compiler The DreamCompiler executable
@@ -249,7 +257,8 @@ fn addMultiFileCompileStep(
     _ = target; // Suppress unused parameter warning
     _ = optimize; // Suppress unused parameter warning
 
-    const step = b.step("multifile-compile", "Compile and link multiple .dr files");
+    const step =
+        b.step("multifile-compile", "Compile and link multiple .dr files");
 
     // This step will be enhanced to accept command-line arguments for input files
     // For now, it demonstrates the framework for multi-file compilation
@@ -273,7 +282,8 @@ fn collectDrSourcesFromDir(b: *std.Build, dir_path: []const u8) []const []const 
     defer arena.deinit();
     var list = std.ArrayList([]const u8).init(arena.allocator());
 
-    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return &.{};
+    var dir =
+        std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return &.{};
     defer dir.close();
 
     var walker = dir.walk(arena.allocator()) catch return &.{};

--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -37,6 +37,7 @@
 - Exception handling with `try`/`catch` statements and `throw`
 - Vulkan handle and struct definitions for interop with the Vulkan API
 - Vulkan helper `dr_vk_enumerate_physical_devices` returns available devices
+- Runtime stubs `dr_vkCreateInstance` and `dr_vkDestroyInstance` call through to Vulkan
 
 ## Missing Features
 

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -97,3 +97,5 @@ Version 1.1.13 (2025-08-10)
 Version 1.1.14 (2025-08-15)
 - Added `dr_vk_enumerate_physical_devices` runtime helper returning a list of
   available devices.
+Version 1.1.15 (2025-08-22)
+- Added `dr_vkCreateInstance` and `dr_vkDestroyInstance` runtime stubs for simple Vulkan setup.

--- a/src/runtime/vulkan.c
+++ b/src/runtime/vulkan.c
@@ -1,0 +1,40 @@
+#include "vulkan.h"
+#include "memory.h"
+#include <string.h>
+#include <vulkan/vulkan.h>
+
+VkResult dr_vkCreateInstance(const DrVkInstanceCreateInfo *info,
+                             VkInstance *outInstance) {
+  if (!info || !outInstance)
+    return VK_ERROR_INITIALIZATION_FAILED;
+
+  VkApplicationInfo appInfo = {
+      .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+      .pNext = NULL,
+      .pApplicationName = info->appInfo ? info->appInfo->applicationName : NULL,
+      .pEngineName = info->appInfo ? info->appInfo->engineName : NULL,
+      .applicationVersion = 0,
+      .engineVersion = 0,
+      .apiVersion =
+          info->appInfo ? info->appInfo->apiVersion : VK_API_VERSION_1_0,
+  };
+
+  VkInstanceCreateInfo ci = {
+      .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+      .pNext = NULL,
+      .flags = 0,
+      .pApplicationInfo = info->appInfo ? &appInfo : NULL,
+      .enabledLayerCount = 0,
+      .ppEnabledLayerNames = NULL,
+      .enabledExtensionCount = info->enabledExtensionCount,
+      .ppEnabledExtensionNames =
+          (const char *const *)info->ppEnabledExtensionNames,
+  };
+
+  return vkCreateInstance(&ci, NULL, outInstance);
+}
+
+void dr_vkDestroyInstance(VkInstance instance) {
+  if (instance)
+    vkDestroyInstance(instance, NULL);
+}

--- a/src/runtime/vulkan.h
+++ b/src/runtime/vulkan.h
@@ -1,0 +1,31 @@
+#ifndef DR_VULKAN_H
+#define DR_VULKAN_H
+
+#include <stdint.h>
+#include <vulkan/vulkan_core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct DrVkApplicationInfo {
+  char *applicationName;
+  char *engineName;
+  uint32_t apiVersion;
+} DrVkApplicationInfo;
+
+typedef struct DrVkInstanceCreateInfo {
+  DrVkApplicationInfo *appInfo;
+  uint32_t enabledExtensionCount;
+  char **ppEnabledExtensionNames;
+} DrVkInstanceCreateInfo;
+
+VkResult dr_vkCreateInstance(const DrVkInstanceCreateInfo *info,
+                             VkInstance *outInstance);
+void dr_vkDestroyInstance(VkInstance instance);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DR_VULKAN_H


### PR DESCRIPTION
## Summary
- implement lightweight Vulkan wrappers in the runtime
- wire runtime build to compile the new vulkan.c file
- document new APIs in FEATURES.md and changelog

## Testing
- `./codex/test_cli.sh quick` *(fails: 87 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ca67a0d6c832ba9a29b61a1baccbf