### PR TITLE
[dreamc] expose Vulkan API via stdlib module

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -38,6 +38,7 @@
 - Vulkan handle and struct definitions for interop with the Vulkan API
 - Vulkan helper `dr_vk_enumerate_physical_devices` returns available devices
 - Runtime stubs `dr_vkCreateInstance` and `dr_vkDestroyInstance` call through to Vulkan
+- Vulkan module exposes `createInstance`, `destroyInstance`, device creation and buffer/memory management functions
 
 ## Missing Features
 

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -99,3 +99,6 @@ Version 1.1.14 (2025-08-15)
   available devices.
 Version 1.1.15 (2025-08-22)
 - Added `dr_vkCreateInstance` and `dr_vkDestroyInstance` runtime stubs for simple Vulkan setup.
+
+Version 1.1.16 (2025-08-30)
+- Published `Vulkan` standard module exposing instance creation, device enumeration and basic device/buffer management functions.

--- a/docs/v1.1/vulkan.md
+++ b/docs/v1.1/vulkan.md
@@ -22,3 +22,36 @@ Console.WriteLine(list.count);
 ```
 
 The returned `VkPhysicalDeviceList` struct contains a pointer to the devices array and a `count` field. Memory for the array is allocated with `dr_alloc` and should be released with `dr_release` when no longer needed.
+
+## Creating and Destroying an Instance
+
+Dream exposes wrappers for `vkCreateInstance` and `vkDestroyInstance` through the `Vulkan` class. Instance creation mirrors the C API closely:
+
+```dream
+VkInstance inst;
+VkResult res = Vulkan.createInstance(&info, &inst);
+if (res != VkResult.Success) {
+  Console.WriteLine("Failed to create instance");
+}
+// ... use the instance ...
+Vulkan.destroyInstance(inst);
+```
+
+Before calling any Vulkan function you can check availability and version using `Vulkan.available()` and `Vulkan.version()`.
+
+## Creating Devices and Buffers
+
+More advanced wrappers directly expose core Vulkan entry points for device and buffer management:
+
+```dream
+VkDevice dev;
+Vulkan.createDevice(list.devices[0], &deviceInfo, null, &dev);
+
+VkBuffer buf;
+Vulkan.createBuffer(dev, &bufferInfo, null, &buf);
+// allocate and bind memory...
+Vulkan.destroyBuffer(dev, buf, null);
+Vulkan.destroyDevice(dev, null);
+```
+
+These APIs retain Vulkan's low-level behaviour, requiring callers to manage memory and error codes just like the native C interface.

--- a/stdlib/Vulkan.dr
+++ b/stdlib/Vulkan.dr
@@ -13,6 +13,8 @@ public struct VkQueue { long value; }
 public struct VkCommandBuffer { long value; }
 public struct VkSurfaceKHR { long value; }
 public struct VkSwapchainKHR { long value; }
+public struct VkBuffer { long value; }
+public struct VkDeviceMemory { long value; }
 
 // Helper structure returned by Vulkan.enumeratePhysicalDevices
 public struct VkPhysicalDeviceList {
@@ -48,7 +50,79 @@ public struct VkInstanceCreateInfo {
   long ppEnabledExtensionNames; // char*[] pointer
 }
 
+// Minimal device creation structures
+public struct VkDeviceQueueCreateInfo {
+  uint queueFamilyIndex;
+  uint queueCount;
+  long pQueuePriorities; // float* pointer
+}
+
+public struct VkDeviceCreateInfo {
+  uint queueCreateInfoCount;
+  VkDeviceQueueCreateInfo* pQueueCreateInfos;
+}
+
+public struct VkBufferCreateInfo {
+  ulong size;
+  uint usage;
+  uint sharingMode;
+}
+
+public struct VkMemoryAllocateInfo {
+  ulong allocationSize;
+  uint memoryTypeIndex;
+}
+
+public struct VkAllocationCallbacks {
+  long userData;
+}
+
 public class Vulkan {
+  @extern("dr_vulkan_available")
+  public static extern int available();
+
+  @extern("dr_vulkan_version")
+  public static extern uint version();
+
+  @extern("dr_vkCreateInstance")
+  public static extern VkResult createInstance(VkInstanceCreateInfo* info,
+                                               VkInstance* outInstance);
+
+  @extern("dr_vkDestroyInstance")
+  public static extern void destroyInstance(VkInstance instance);
+
   @extern("dr_vk_enumerate_physical_devices")
   public static extern VkPhysicalDeviceList enumeratePhysicalDevices(VkInstance instance);
+
+  @extern("vkCreateDevice")
+  public static extern VkResult createDevice(VkPhysicalDevice physicalDevice,
+                                             VkDeviceCreateInfo* info,
+                                             VkAllocationCallbacks* alloc,
+                                             VkDevice* outDevice);
+
+  @extern("vkDestroyDevice")
+  public static extern void destroyDevice(VkDevice device,
+                                          VkAllocationCallbacks* alloc);
+
+  @extern("vkCreateBuffer")
+  public static extern VkResult createBuffer(VkDevice device,
+                                             VkBufferCreateInfo* info,
+                                             VkAllocationCallbacks* alloc,
+                                             VkBuffer* outBuffer);
+
+  @extern("vkDestroyBuffer")
+  public static extern void destroyBuffer(VkDevice device,
+                                          VkBuffer buffer,
+                                          VkAllocationCallbacks* alloc);
+
+  @extern("vkAllocateMemory")
+  public static extern VkResult allocateMemory(VkDevice device,
+                                               VkMemoryAllocateInfo* info,
+                                               VkAllocationCallbacks* alloc,
+                                               VkDeviceMemory* outMemory);
+
+  @extern("vkFreeMemory")
+  public static extern void freeMemory(VkDevice device,
+                                       VkDeviceMemory memory,
+                                       VkAllocationCallbacks* alloc);
 }


### PR DESCRIPTION
## Summary
- add extern Vulkan APIs to stdlib module
- document usage in Vulkan docs
- record Vulkan module in changelog and feature list

## Testing
- `zig build`
- `./codex/test_cli.sh quick`

------
https://chatgpt.com/codex/tasks/task_e_687ca89b8f8c832ba888f1d98d555fcb