### PR TITLE
Add cross-platform Vulkan surface helpers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -151,6 +151,11 @@ pub fn build(b: *std.Build) void {
         runtime_lib.addIncludePath(.{ .cwd_relative = p });
         if (vk_lib) |lib| runtime_lib.addLibraryPath(.{ .cwd_relative = lib });
         runtime_lib.linkSystemLibrary(if (target.result.os.tag == .windows) "vulkan-1" else "vulkan");
+        if (target.result.os.tag == .windows) {
+            runtime_lib.linkSystemLibrary("user32");
+        } else if (target.result.os.tag == .linux) {
+            runtime_lib.linkSystemLibrary("xcb");
+        }
     }
     runtime_lib.linkLibC();
     b.installArtifact(runtime_lib);

--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -39,6 +39,7 @@
 - Vulkan helper `dr_vk_enumerate_physical_devices` returns available devices
 - Runtime stubs `dr_vkCreateInstance` and `dr_vkDestroyInstance` call through to Vulkan
 - Vulkan module exposes `createInstance`, `destroyInstance`, device creation and buffer/memory management functions
+- Cross-platform surface creation via `dr_vkCreateSurface` and `dr_vkDestroySurface`
 
 ## Missing Features
 

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -102,3 +102,7 @@ Version 1.1.15 (2025-08-22)
 
 Version 1.1.16 (2025-08-30)
 - Published `Vulkan` standard module exposing instance creation, device enumeration and basic device/buffer management functions.
+
+Version 1.1.17 (2025-09-05)
+- Added cross-platform surface creation wrappers `dr_vkCreateSurface` and `dr_vkDestroySurface`.
+- Runtime library now links against `user32` on Windows or `xcb` on Linux for WSI.

--- a/docs/v1.1/vulkan.md
+++ b/docs/v1.1/vulkan.md
@@ -55,3 +55,22 @@ Vulkan.destroyDevice(dev, null);
 ```
 
 These APIs retain Vulkan's low-level behaviour, requiring callers to manage memory and error codes just like the native C interface.
+
+## Creating Window Surfaces
+
+To present to a window you must create a `VkSurfaceKHR` for your platform. `Vulkan.createSurface` wraps the platform-specific calls and accepts a `VkSurfaceCreateInfo` structure with native handles:
+
+```dream
+VkSurfaceCreateInfo surfInfo = new VkSurfaceCreateInfo();
+surfInfo.handle1 = getPlatformInstance(); // HINSTANCE or xcb_connection_t*
+surfInfo.handle2 = getPlatformWindow();   // HWND or xcb_window_t
+
+VkSurfaceKHR surface;
+VkResult res = Vulkan.createSurface(inst, &surfInfo, &surface);
+```
+
+Destroy a surface when finished:
+
+```dream
+Vulkan.destroySurface(inst, surface);
+```

--- a/src/runtime/vulkan.c
+++ b/src/runtime/vulkan.c
@@ -1,6 +1,13 @@
 #include "vulkan.h"
 #include "memory.h"
 #include <string.h>
+#ifdef _WIN32
+#define VK_USE_PLATFORM_WIN32_KHR
+#include <windows.h>
+#elif defined(__linux__)
+#define VK_USE_PLATFORM_XCB_KHR
+#include <xcb/xcb.h>
+#endif
 #include <vulkan/vulkan.h>
 
 VkResult dr_vkCreateInstance(const DrVkInstanceCreateInfo *info,
@@ -37,4 +44,55 @@ VkResult dr_vkCreateInstance(const DrVkInstanceCreateInfo *info,
 void dr_vkDestroyInstance(VkInstance instance) {
   if (instance)
     vkDestroyInstance(instance, NULL);
+}
+
+VkResult dr_vkCreateSurface(VkInstance instance,
+                            const DrVkSurfaceCreateInfo *info,
+                            VkSurfaceKHR *outSurface) {
+  if (!info || !outSurface)
+    return VK_ERROR_INITIALIZATION_FAILED;
+#ifdef _WIN32
+  VkWin32SurfaceCreateInfoKHR ci = {
+      .sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
+      .pNext = NULL,
+      .flags = 0,
+      .hinstance = (HINSTANCE)info->hinstance,
+      .hwnd = (HWND)info->hwnd,
+  };
+  PFN_vkCreateWin32SurfaceKHR pfn =
+      (PFN_vkCreateWin32SurfaceKHR)vkGetInstanceProcAddr(
+          instance, "vkCreateWin32SurfaceKHR");
+  if (!pfn)
+    return VK_ERROR_EXTENSION_NOT_PRESENT;
+  return pfn(instance, &ci, NULL, outSurface);
+#elif defined(__linux__)
+  VkXcbSurfaceCreateInfoKHR ci = {
+      .sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR,
+      .pNext = NULL,
+      .flags = 0,
+      .connection = (xcb_connection_t *)info->connection,
+      .window = info->window,
+  };
+  PFN_vkCreateXcbSurfaceKHR pfn =
+      (PFN_vkCreateXcbSurfaceKHR)vkGetInstanceProcAddr(
+          instance, "vkCreateXcbSurfaceKHR");
+  if (!pfn)
+    return VK_ERROR_EXTENSION_NOT_PRESENT;
+  return pfn(instance, &ci, NULL, outSurface);
+#else
+  (void)instance;
+  (void)info;
+  (void)outSurface;
+  return VK_ERROR_EXTENSION_NOT_PRESENT;
+#endif
+}
+
+void dr_vkDestroySurface(VkInstance instance, VkSurfaceKHR surface) {
+  if (!surface)
+    return;
+  PFN_vkDestroySurfaceKHR pfn =
+      (PFN_vkDestroySurfaceKHR)vkGetInstanceProcAddr(
+          instance, "vkDestroySurfaceKHR");
+  if (pfn)
+    pfn(instance, surface, NULL);
 }

--- a/src/runtime/vulkan.h
+++ b/src/runtime/vulkan.h
@@ -20,9 +20,26 @@ typedef struct DrVkInstanceCreateInfo {
   char **ppEnabledExtensionNames;
 } DrVkInstanceCreateInfo;
 
+typedef struct DrVkSurfaceCreateInfo {
+#ifdef _WIN32
+  void *hinstance;
+  void *hwnd;
+#elif defined(__linux__)
+  void *connection;
+  uint32_t window;
+#else
+  void *unused1;
+  void *unused2;
+#endif
+} DrVkSurfaceCreateInfo;
+
 VkResult dr_vkCreateInstance(const DrVkInstanceCreateInfo *info,
                              VkInstance *outInstance);
 void dr_vkDestroyInstance(VkInstance instance);
+VkResult dr_vkCreateSurface(VkInstance instance,
+                            const DrVkSurfaceCreateInfo *info,
+                            VkSurfaceKHR *outSurface);
+void dr_vkDestroySurface(VkInstance instance, VkSurfaceKHR surface);
 
 #ifdef __cplusplus
 }

--- a/stdlib/Vulkan.dr
+++ b/stdlib/Vulkan.dr
@@ -73,6 +73,14 @@ public struct VkMemoryAllocateInfo {
   uint memoryTypeIndex;
 }
 
+// Platform surface creation info
+// Windows: hinstance & hwnd
+// Linux:  xcb_connection_t* & window id
+public struct VkSurfaceCreateInfo {
+  long handle1;
+  long handle2;
+}
+
 public struct VkAllocationCallbacks {
   long userData;
 }
@@ -125,4 +133,13 @@ public class Vulkan {
   public static extern void freeMemory(VkDevice device,
                                        VkDeviceMemory memory,
                                        VkAllocationCallbacks* alloc);
+
+  @extern("dr_vkCreateSurface")
+  public static extern VkResult createSurface(VkInstance instance,
+                                              VkSurfaceCreateInfo* info,
+                                              VkSurfaceKHR* outSurface);
+
+  @extern("dr_vkDestroySurface")
+  public static extern void destroySurface(VkInstance instance,
+                                           VkSurfaceKHR surface);
 }


### PR DESCRIPTION
## Summary
- support creating window surfaces via Win32 or XCB in runtime
- expose `createSurface`/`destroySurface` in the Vulkan module
- link WSI libraries on each platform
- document the new APIs and update feature list

## Testing
- `zig build`
- `python codex/test_cli.py quick`

------
https://chatgpt.com/codex/tasks/task_e_687caabdd414832b84dd242a582a404e