### PR TITLE
Extend Vulkan bindings for pipeline setup

### DIFF
--- a/codex/FEATURES.md
+++ b/codex/FEATURES.md
@@ -40,6 +40,7 @@
 - Runtime stubs `dr_vkCreateInstance` and `dr_vkDestroyInstance` call through to Vulkan
 - Vulkan module exposes `createInstance`, `destroyInstance`, device creation and buffer/memory management functions
 - Cross-platform surface creation via `dr_vkCreateSurface` and `dr_vkDestroySurface`
+- Pipeline building helpers: shader modules, descriptor set layouts and pipeline layouts
 
 ## Missing Features
 

--- a/docs/v1.1/changelog.md
+++ b/docs/v1.1/changelog.md
@@ -110,3 +110,8 @@ Version 1.1.17 (2025-09-05)
 Version 1.1.18 (2025-09-12)
 - Added `dr_vkCreateSimpleSwapchain` runtime helper and Dream wrappers `createDefaultSwapchain` and `destroySwapchain`.
 - New `pickFirstPhysicalDevice` helper simplifies choosing a GPU.
+
+Version 1.1.19 (2025-09-28)
+- Expanded Vulkan module with shader module, descriptor set layout and pipeline
+  layout bindings.
+- Documentation updated with examples for building pipelines.

--- a/docs/v1.1/vulkan.md
+++ b/docs/v1.1/vulkan.md
@@ -96,3 +96,44 @@ Vulkan.createDefaultSwapchain(device, surface, 800, 600, &swap);
 // ... use the swapchain ...
 Vulkan.destroySwapchain(device, swap);
 ```
+
+## Shader Modules and Pipeline Layouts
+
+The module also exposes low-level entry points for building graphics pipelines.
+Shader modules are created directly from SPIR-V bytecode using
+`Vulkan.createShaderModule`:
+
+```dream
+VkShaderModuleCreateInfo smInfo = new VkShaderModuleCreateInfo();
+smInfo.codeSize = spirvSize;
+smInfo.pCode = spirvPtr;
+VkShaderModule shader;
+VkResult res = Vulkan.createShaderModule(device, &smInfo, null, &shader);
+```
+
+Descriptor set layouts and pipeline layouts mirror the C API closely:
+
+```dream
+VkDescriptorSetLayoutBinding bind = new VkDescriptorSetLayoutBinding();
+bind.binding = 0;
+bind.descriptorType = 0; // VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+bind.descriptorCount = 1;
+bind.stageFlags = 1;     // VK_SHADER_STAGE_VERTEX_BIT
+
+VkDescriptorSetLayoutCreateInfo dl = new VkDescriptorSetLayoutCreateInfo();
+dl.bindingCount = 1;
+dl.pBindings = &bind;
+VkDescriptorSetLayout setLayout;
+Vulkan.createDescriptorSetLayout(device, &dl, null, &setLayout);
+
+VkPipelineLayoutCreateInfo pl = new VkPipelineLayoutCreateInfo();
+pl.setLayoutCount = 1;
+pl.pSetLayouts = &setLayout;
+pl.pushConstantRangeCount = 0;
+pl.pPushConstantRanges = 0;
+VkPipelineLayout layout;
+Vulkan.createPipelineLayout(device, &pl, null, &layout);
+```
+
+Destroy these objects with `destroyShaderModule`, `destroyDescriptorSetLayout`
+and `destroyPipelineLayout` when no longer needed.

--- a/stdlib/Vulkan.dr
+++ b/stdlib/Vulkan.dr
@@ -15,6 +15,11 @@ public struct VkSurfaceKHR { long value; }
 public struct VkSwapchainKHR { long value; }
 public struct VkBuffer { long value; }
 public struct VkDeviceMemory { long value; }
+public struct VkShaderModule { long value; }
+public struct VkPipelineLayout { long value; }
+public struct VkDescriptorSetLayout { long value; }
+public struct VkDescriptorPool { long value; }
+public struct VkDescriptorSet { long value; }
 
 // Helper structure returned by Vulkan.enumeratePhysicalDevices
 public struct VkPhysicalDeviceList {
@@ -71,6 +76,31 @@ public struct VkBufferCreateInfo {
 public struct VkMemoryAllocateInfo {
   ulong allocationSize;
   uint memoryTypeIndex;
+}
+
+public struct VkShaderModuleCreateInfo {
+  ulong codeSize;
+  long  pCode; // uint32_t* pointer
+}
+
+public struct VkDescriptorSetLayoutBinding {
+  uint binding;
+  uint descriptorType;
+  uint descriptorCount;
+  uint stageFlags;
+  long pImmutableSamplers; // VkSampler* pointer
+}
+
+public struct VkDescriptorSetLayoutCreateInfo {
+  uint bindingCount;
+  VkDescriptorSetLayoutBinding* pBindings;
+}
+
+public struct VkPipelineLayoutCreateInfo {
+  uint setLayoutCount;
+  VkDescriptorSetLayout* pSetLayouts;
+  uint pushConstantRangeCount;
+  long pPushConstantRanges; // VkPushConstantRange* pointer
 }
 
 // Platform surface creation info
@@ -133,6 +163,39 @@ public class Vulkan {
   public static extern void freeMemory(VkDevice device,
                                        VkDeviceMemory memory,
                                        VkAllocationCallbacks* alloc);
+
+  @extern("vkCreateShaderModule")
+  public static extern VkResult createShaderModule(VkDevice device,
+                                                   VkShaderModuleCreateInfo* info,
+                                                   VkAllocationCallbacks* alloc,
+                                                   VkShaderModule* outModule);
+
+  @extern("vkDestroyShaderModule")
+  public static extern void destroyShaderModule(VkDevice device,
+                                                VkShaderModule module,
+                                                VkAllocationCallbacks* alloc);
+
+  @extern("vkCreateDescriptorSetLayout")
+  public static extern VkResult createDescriptorSetLayout(VkDevice device,
+                                                          VkDescriptorSetLayoutCreateInfo* info,
+                                                          VkAllocationCallbacks* alloc,
+                                                          VkDescriptorSetLayout* outLayout);
+
+  @extern("vkDestroyDescriptorSetLayout")
+  public static extern void destroyDescriptorSetLayout(VkDevice device,
+                                                       VkDescriptorSetLayout layout,
+                                                       VkAllocationCallbacks* alloc);
+
+  @extern("vkCreatePipelineLayout")
+  public static extern VkResult createPipelineLayout(VkDevice device,
+                                                     VkPipelineLayoutCreateInfo* info,
+                                                     VkAllocationCallbacks* alloc,
+                                                     VkPipelineLayout* outLayout);
+
+  @extern("vkDestroyPipelineLayout")
+  public static extern void destroyPipelineLayout(VkDevice device,
+                                                  VkPipelineLayout layout,
+                                                  VkAllocationCallbacks* alloc);
 
   @extern("dr_vkCreateSurface")
   public static extern VkResult createSurface(VkInstance instance,

--- a/tests/graphics/vulkan_pipeline.dr
+++ b/tests/graphics/vulkan_pipeline.dr
@@ -1,0 +1,34 @@
+func int main() {
+    VkShaderModuleCreateInfo smi = new VkShaderModuleCreateInfo();
+    smi.codeSize = 0;
+    smi.pCode = 0;
+    VkShaderModule mod;
+    Vulkan.createShaderModule(new VkDevice(), &smi, null, &mod);
+
+    VkDescriptorSetLayoutBinding bind = new VkDescriptorSetLayoutBinding();
+    bind.binding = 0;
+    bind.descriptorType = 0;
+    bind.descriptorCount = 1;
+    bind.stageFlags = 0;
+    bind.pImmutableSamplers = 0;
+
+    VkDescriptorSetLayoutCreateInfo dl = new VkDescriptorSetLayoutCreateInfo();
+    dl.bindingCount = 1;
+    dl.pBindings = &bind;
+    VkDescriptorSetLayout setLayout;
+    Vulkan.createDescriptorSetLayout(new VkDevice(), &dl, null, &setLayout);
+
+    VkPipelineLayoutCreateInfo pl = new VkPipelineLayoutCreateInfo();
+    pl.setLayoutCount = 1;
+    pl.pSetLayouts = &setLayout;
+    pl.pushConstantRangeCount = 0;
+    pl.pPushConstantRanges = 0;
+    VkPipelineLayout layout;
+    Vulkan.createPipelineLayout(new VkDevice(), &pl, null, &layout);
+
+    Vulkan.destroyPipelineLayout(new VkDevice(), layout, null);
+    Vulkan.destroyDescriptorSetLayout(new VkDevice(), setLayout, null);
+    Vulkan.destroyShaderModule(new VkDevice(), mod, null);
+    Console.WriteLine("ok"); // Expected: C code generated successfully
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expand the Vulkan standard module with shader module, descriptor set layout and pipeline layout bindings
- document new Vulkan capabilities and update change log
- list new pipeline helpers in FEATURES
- add a small compilation test for the new API

## Testing
- `zig build`
- `./codex/test_cli.sh quick`
- `python codex/test_cli.py quick`


------
https://chatgpt.com/codex/tasks/task_e_687cb42bcdec832b9c6f2baae89aea1f