### PR TITLE
[dreamc] Fix test runner linking runtime

### DIFF
--- a/src/driver/main.c
+++ b/src/driver/main.c
@@ -177,7 +177,7 @@ int main(int argc, char *argv[]) {
     dr_mkdir("build/libs");
     
     // Copy runtime headers to build/libs for distribution
-    const char *headers[] = {"console.h", "memory.h", "custom.h", "task.h"};
+    const char *headers[] = {"console.h", "memory.h", "custom.h", "task.h", "exception.h"};
     for (size_t i = 0; i < sizeof(headers)/sizeof(headers[0]); i++) {
       char src_path[256], dst_path[256];
       snprintf(src_path, sizeof(src_path), "src%cruntime%c%s", DR_PATH_SEP, DR_PATH_SEP, headers[i]);


### PR DESCRIPTION
## Summary
- update runtime header copy list
- link libdreamrt.a when running tests
- update Python test helpers to build and run linked executable

## Testing
- `python codex/python/test_runner.py --filter "basics/arithmetic/arithmetic.dr" --debug`
- `./codex/test_cli.sh quick`

------
https://chatgpt.com/codex/tasks/task_e_687cb745b200832bbfae8d26a0c94c02