### PR TITLE
[dreamc] fix Linux tests

### DIFF
--- a/codex/python/test_manager.py
+++ b/codex/python/test_manager.py
@@ -283,11 +283,13 @@ class TestManager:
         exe_path = ROOT / exe
         
         # Link with individual runtime source files for better compatibility
+        # Runtime sources moved into subdirectories; use new paths
         runtime_files = [
-            "src/runtime/memory.c",
-            "src/runtime/console.c", 
-            "src/runtime/custom.c",
-            "src/runtime/exception.c"
+            "src/runtime/memory/memory.c",
+            "src/runtime/io/console.c",
+            "src/runtime/extensions/custom.c",
+            "src/runtime/exceptions/exception.c",
+            "src/runtime/system/task.c",
         ]
         
         cc_cmd = [


### PR DESCRIPTION
## What changed
- updated `test_manager.py` runtime paths to match new directory structure

## How it was tested
- `./codex/test_cli.sh quick`

## Docs updated
- none

## Dependencies
- none

------
https://chatgpt.com/codex/tasks/task_e_687e3bb49194832b9ce95c307774c94a