### PR TITLE
[dreamc] record latest linux test results

### DIFF
--- a/tasks/LastTestSuite-Linux.md
+++ b/tasks/LastTestSuite-Linux.md
@@ -1,0 +1,32 @@
+# Last Test Suite - Linux
+
+**Date:** July 22, 2025
+
+## Go Tests
+Attempted to run `make quick-validate` and the minimal test suite, but Go tests failed with the error:
+```
+use of cgo in test dream_minimal_test.go not supported
+```
+
+## Python Tests
+Command: `python codex/test_cli.py quick`
+- **Total Tests:** 113
+- **Passed:** 88
+- **Failed:** 0
+- **Skipped:** 23
+- **Errors:** 2
+- **Duration:** ~40s
+
+Last lines of the Python test log:
+```
+Failed:      0
+Skipped:     23
+Errors:      2
+
+Category Breakdown:
+  integration   20/ 21 ( 95.2%)
+  unit          63/ 85 ( 74.1%)
+  regression     2/  4 ( 50.0%)
+  semantic       3/  3 (100.0%)
+================================================================================
+```


### PR DESCRIPTION
## Summary
- document the most recent test run on Linux

## Testing
- `make quick-validate` *(fails: use of cgo in test dream_minimal_test.go not supported)*
- `python codex/test_cli.py quick`


------
https://chatgpt.com/codex/tasks/task_e_687f11345a78832b87552cfdb86915ed